### PR TITLE
Require `subsamples` on input for the QPU reverse annealing

### DIFF
--- a/hybrid/samplers.py
+++ b/hybrid/samplers.py
@@ -160,7 +160,9 @@ class QPUSubproblemAutoEmbeddingSampler(traits.SubproblemSampler, traits.SISO, R
         return state.updated(subsamples=response)
 
 
-class ReverseAnnealingAutoEmbeddingSampler(traits.SubproblemSampler, traits.SISO, Runnable):
+class ReverseAnnealingAutoEmbeddingSampler(traits.SubproblemSampler,
+                                           traits.SubsamplesIntaking,
+                                           traits.SISO, Runnable):
     r"""A quantum reverse annealing sampler for a subproblem with automated
     heuristic minor-embedding.
 


### PR DESCRIPTION
Although all (sub)samplers use (sub)sample from input, if available, to
seed the `initial_states`, they can also work without it, in which case
random states are generated.

Fixes #177.