### PR TITLE
Make system load-sensitive concurrency tests a bit more robust

### DIFF
--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -62,7 +62,7 @@ class TestImmediateExecutor(unittest.TestCase):
 
 class TestMultithreading(unittest.TestCase, RunTimeAssertionMixin):
 
-    def test_concurrent_tabu_samples(self):
+    def test_tabu_concurrency(self):
         t1 = hybrid.TabuProblemSampler(timeout=1000)
         t2 = hybrid.TabuProblemSampler(timeout=2000)
         workflow = hybrid.Parallel(t1, t2)
@@ -74,7 +74,7 @@ class TestMultithreading(unittest.TestCase, RunTimeAssertionMixin):
             workflow.run(state).result()
 
     @unittest.skipUnless(cpu_count() >= 2, "at least two threads required")
-    def test_concurrent_sa_samples(self):
+    def test_sa_concurrency(self):
         params = dict(num_reads=1, num_sweeps=1000000)
 
         # serial and parallel SA runs
@@ -90,26 +90,30 @@ class TestMultithreading(unittest.TestCase, RunTimeAssertionMixin):
         bqm = dimod.generators.uniform(graph=1, vartype=dimod.SPIN)
         state = hybrid.State.from_problem(bqm)
 
-        # wall clock workflow runtime for `repeat` runs
+        # average wall clock workflow runtime over `repeat` runs
         def time_workflow(workflow, state, repeat=10):
             with hybrid.tictoc() as timer:
                 for _ in range(repeat):
                     workflow.run(state).result()
-            return timer.dt
+            return timer.dt / repeat
 
-        # run multiple times, pick best speed-up, in case system temporarily busy
+        # measure speed-up of parallel SA runs over sequential
+
+        # NOTE: on average, the observed speed-up is between 1.5x and 2x, but
+        # it's highly dependant on the system load and availability of threads.
+        # That's why we do multiple runs, and pick the best speed-up.
         speedups = []
         for _ in range(7):
             t_s = time_workflow(s, state)
             t_p = time_workflow(p, state)
             speedups.append(t_s / t_p)
 
-        # NOTE: debugging CI
+        # tmp
         print(speedups)
 
         speedup = max(speedups)
 
         # NOTE: the extremely weak lower bound on speedup was chosen so we don't
-        # fail on the unreliable/inconsistent CI VMs, and but to show some
-        # concurrency does exist
+        # fail on the unreliable/inconsistent CI VMs, but to verify some level
+        # of concurrency does exist
         self.assertGreater(speedup, 1.25)

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -97,15 +97,17 @@ class TestMultithreading(unittest.TestCase, RunTimeAssertionMixin):
                     workflow.run(state).result()
             return timer.dt
 
-        # do two warm-up runs before the actual measurement
-        for _ in range(3):
+        # run multiple times, pick best speed-up, in case system temporarily busy
+        speedups = []
+        for _ in range(7):
             t_s = time_workflow(s, state)
             t_p = time_workflow(p, state)
+            speedups.append(t_s / t_p)
 
-        speedup = t_s / t_p
+        # NOTE: debugging CI
+        print(speedups)
 
-        # NOTE: temporary for debugging on CI only
-        print(speedup)
+        speedup = max(speedups)
 
         # NOTE: the extremely weak lower bound on speedup was chosen so we don't
         # fail on the unreliable/inconsistent CI VMs, and but to show some


### PR DESCRIPTION
Focus on computationally/CPU intensive parts. Collect better run stats, run many times before failing if system is unstable.