### PR TITLE
Update population annealing

### DIFF
--- a/hybrid/flow.py
+++ b/hybrid/flow.py
@@ -856,7 +856,7 @@ class SimpleIterator(LoopUntilNoImprovement):
         super(SimpleIterator, self).__init__(*args, **kwargs)
 
         warnings.warn("SimpleIterator is deprecated, please use Loop instead.",
-                        DeprecationWarning)
+                      DeprecationWarning)
 
 
 class LoopWhileNoImprovement(LoopUntilNoImprovement):

--- a/hybrid/reference/pa.py
+++ b/hybrid/reference/pa.py
@@ -168,7 +168,7 @@ class CalculateAnnealingBetaSchedule(hybrid.traits.SISO, hybrid.Runnable):
         return state.updated(beta_schedule=beta_schedule)
 
 
-def PopulationAnnealing(num_reads=20, num_iter=20, num_sweeps=1000):
+def PopulationAnnealing(num_reads=100, num_iter=100, num_sweeps=100):
     """Population annealing workflow generator.
 
     Args:
@@ -198,7 +198,7 @@ def PopulationAnnealing(num_reads=20, num_iter=20, num_sweeps=1000):
     return workflow
 
 
-def HybridizedPopulationAnnealing(num_reads=20, num_iter=20, num_sweeps=1000):
+def HybridizedPopulationAnnealing(num_reads=100, num_iter=100, num_sweeps=100):
     """Workflow generator for population annealing initialized with QPU samples.
 
     Args:

--- a/hybrid/reference/pa.py
+++ b/hybrid/reference/pa.py
@@ -141,20 +141,31 @@ class CalculateAnnealingBetaSchedule(hybrid.traits.SISO, hybrid.Runnable):
             * linear
             * geometric
 
-    See:
-        :meth:`neal.default_beta_range`.
+        beta_range (tuple[float], optional):
+            A 2-tuple defining the beginning and end of the beta schedule,
+            where beta is the inverse temperature. The schedule is derived by
+            interpolating the range with ``interpolation`` method. Default range
+            is set based on the total bias associated with each node (see
+            :meth:`neal.default_beta_range`).
+
     """
 
-    def __init__(self, length=2, interpolation='linear', **runopts):
+    def __init__(self, length=2, interpolation='linear', beta_range=None, **runopts):
         super(CalculateAnnealingBetaSchedule, self).__init__(**runopts)
         self.length = length
         self.interpolation = interpolation
+        self.beta_range = beta_range
 
     def next(self, state, **runopts):
         bqm = state.problem
 
-        # get a reasonable beta range
-        beta_hot, beta_cold = neal.default_beta_range(bqm)
+        if self.beta_range is None:
+            # get a reasonable beta range
+            beta_range = neal.default_beta_range(bqm)
+        else:
+            beta_range = self.beta_range
+
+        beta_hot, beta_cold = beta_range
 
         # generate betas
         if self.interpolation == 'linear':

--- a/hybrid/reference/pa.py
+++ b/hybrid/reference/pa.py
@@ -132,7 +132,7 @@ class CalculateAnnealingBetaSchedule(hybrid.traits.SISO, hybrid.Runnable):
         length (int):
             Length of the produced beta schedule.
 
-        interpolation (str, optional, default='geometric'):
+        interpolation (str, optional, default='linear'):
             Interpolation used between the hot and the cold beta. Supported
             values are:
 
@@ -143,7 +143,7 @@ class CalculateAnnealingBetaSchedule(hybrid.traits.SISO, hybrid.Runnable):
         :meth:`neal.default_beta_range`.
     """
 
-    def __init__(self, length=2, interpolation='geometric', **runopts):
+    def __init__(self, length=2, interpolation='linear', **runopts):
         super(CalculateAnnealingBetaSchedule, self).__init__(**runopts)
         self.length = length
         self.interpolation = interpolation

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -141,3 +141,13 @@ class TestPopulationAnnealing(unittest.TestCase):
         ss = pa.run(state).result().samples
 
         self.assertDictEqual(ss.first.sample, ground)
+
+    def test_custom_beta_schedule(self):
+        bqm = dimod.BinaryQuadraticModel({0: -1, 1: 0.01}, {}, 0, 'BINARY')
+        ground = {0: 1, 1: 0}
+        state = hybrid.State.from_problem(bqm)
+
+        pa = PopulationAnnealing(num_reads=1, num_iter=10, num_sweeps=10, beta_range=[0, 1000])
+        ss = pa.run(state).result().samples
+
+        self.assertDictEqual(ss.first.sample, ground)

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -21,7 +21,7 @@ import hybrid
 from hybrid.reference.kerberos import KerberosSampler
 from hybrid.reference.pa import (
     EnergyWeightedResampler, ProgressBetaAlongSchedule,
-    CalculateAnnealingBetaSchedule
+    CalculateAnnealingBetaSchedule, PopulationAnnealing
 )
 
 
@@ -112,3 +112,25 @@ class TestPopulationAnnealingUtils(unittest.TestCase):
         res = calc.run(state).result()
         self.assertIn('beta_schedule', res)
         self.assertEqual(len(res.beta_schedule), 10)
+
+
+class TestPopulationAnnealing(unittest.TestCase):
+
+    def test_smoke(self):
+        bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': 1})
+        state = hybrid.State.from_problem(bqm)
+
+        pa = PopulationAnnealing()
+        ss = pa.run(state).result().samples
+
+        self.assertEqual(ss.first.energy, -1)
+
+    def test_range(self):
+        bqm = dimod.BinaryQuadraticModel({0: -1, 1: 0.01}, {}, 0, 'BINARY')
+        ground = {0: 1, 1: 0}
+        state = hybrid.State.from_problem(bqm)
+
+        pa = PopulationAnnealing(num_reads=1, num_iter=10, num_sweeps=100)
+        ss = pa.run(state).result().samples
+
+        self.assertDictEqual(ss.first.sample, ground)

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -113,6 +113,13 @@ class TestPopulationAnnealingUtils(unittest.TestCase):
         self.assertIn('beta_schedule', res)
         self.assertEqual(len(res.beta_schedule), 10)
 
+        # user-provided range
+        calc = CalculateAnnealingBetaSchedule(
+            length=3, interpolation='linear', beta_range=[0, 1])
+        res = calc.run(state).result()
+        self.assertIn('beta_schedule', res)
+        self.assertEqual(list(res.beta_schedule), [0, 0.5, 1])
+
 
 class TestPopulationAnnealing(unittest.TestCase):
 

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -47,14 +47,14 @@ class TestWeightedResampler(unittest.TestCase):
         state = hybrid.State(samples=skewed)
 
         # cold sampling
-        res = EnergyWeightedResampler(beta=1, seed=1234).run(state).result()
+        res = EnergyWeightedResampler(delta_beta=1, seed=1234).run(state).result()
         samples = res.samples.aggregate()
 
         self.assertEqual(len(samples), 1)
-        self.assertDictEqual(dict(list(samples.samples())[0]), winner)
+        self.assertDictEqual(samples.first.sample, winner)
 
         # hot sampling
-        res = EnergyWeightedResampler(beta=0, seed=1234).run(state).result()
+        res = EnergyWeightedResampler(delta_beta=0, seed=1234).run(state).result()
         samples = res.samples.aggregate()
 
         self.assertGreater(len(samples), 1)
@@ -68,17 +68,17 @@ class TestWeightedResampler(unittest.TestCase):
             res = EnergyWeightedResampler().run(state).result()
 
         # beta given on construction
-        res = EnergyWeightedResampler(beta=0).run(state).result()
-        self.assertEqual(res.samples.info['beta'], 0)
+        res = EnergyWeightedResampler(delta_beta=0).run(state).result()
+        self.assertEqual(res.samples.info['delta_beta'], 0)
 
         # beta given on runtime, to run method
-        res = EnergyWeightedResampler().run(state, beta=1).result()
-        self.assertEqual(res.samples.info['beta'], 1)
+        res = EnergyWeightedResampler().run(state, delta_beta=1).result()
+        self.assertEqual(res.samples.info['delta_beta'], 1)
 
         # beta given in state
-        state.beta = 2
+        state.delta_beta = 2
         res = EnergyWeightedResampler().run(state).result()
-        self.assertEqual(res.samples.info['beta'], 2)
+        self.assertEqual(res.samples.info['delta_beta'], 2)
 
 
 class TestPopulationAnnealingUtils(unittest.TestCase):


### PR DESCRIPTION
Improves energy range, uses resampling based on delta beta, adds support for user-supplied beta schedule.

Changes:
- `EnergyWeightedResampler` uses `delta_beta` parameter instead of `beta`. Deprecated for now, but should be OK to remove soon, as this is rather internal.

Closes #234.