### PR TITLE
Add logging block

### DIFF
--- a/hybrid/utils.py
+++ b/hybrid/utils.py
@@ -60,6 +60,27 @@ class NumpyEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
+class OceanEncoder(NumpyEncoder):
+    """JSON encoder for common Ocean types.
+
+    Use for convenience output/logging/inspection only, not for robust
+    serialization (not all info required for reconstruction is dumped)!
+
+    Supported types:
+     - numpy types (see :class:`~hybrid.utils.NumpyEncoder`)
+     - BinaryQuadraticModel (serialized as "numpy vectors")
+     - SampleSet
+    """
+
+    def default(self, obj):
+        if isinstance(obj, dimod.BinaryQuadraticModel):
+            return obj.to_numpy_vectors(return_labels=True)._asdict()
+        elif isinstance(obj, dimod.SampleSet):
+            return obj.to_serializable()
+
+        return super().default(obj)
+
+
 def bqm_density(bqm):
     """Calculate BQM's graph density."""
 

--- a/hybrid/utils.py
+++ b/hybrid/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import random
 
 import numpy
@@ -36,6 +37,27 @@ def cpu_count():    # pragma: no cover
         pass
 
     return 1
+
+
+class NumpyEncoder(json.JSONEncoder):
+    """JSON encoder for numpy types.
+
+    Supported types:
+     - basic numeric types: booleans, integers, floats
+     - arrays: ndarray, recarray
+    """
+
+    def default(self, obj):
+        if isinstance(obj, numpy.integer):
+            return int(obj)
+        elif isinstance(obj, numpy.floating):
+            return float(obj)
+        elif isinstance(obj, numpy.bool_):
+            return bool(obj)
+        elif isinstance(obj, numpy.ndarray):
+            return obj.tolist()
+
+        return super().default(obj)
 
 
 def bqm_density(bqm):

--- a/hybrid/utils.py
+++ b/hybrid/utils.py
@@ -14,6 +14,7 @@
 
 import json
 import random
+import datetime
 
 import numpy
 
@@ -73,7 +74,9 @@ class OceanEncoder(NumpyEncoder):
     """
 
     def default(self, obj):
-        if isinstance(obj, dimod.BinaryQuadraticModel):
+        if isinstance(obj, datetime.datetime):
+            return obj.isoformat()
+        elif isinstance(obj, dimod.BinaryQuadraticModel):
             return obj.to_numpy_vectors(return_labels=True)._asdict()
         elif isinstance(obj, dimod.SampleSet):
             return obj.to_serializable()

--- a/hybrid/utils.py
+++ b/hybrid/utils.py
@@ -77,7 +77,11 @@ class OceanEncoder(NumpyEncoder):
         if isinstance(obj, datetime.datetime):
             return obj.isoformat()
         elif isinstance(obj, dimod.BinaryQuadraticModel):
-            return obj.to_numpy_vectors(return_labels=True)._asdict()
+            # in dimod > 0.10, to_numpy_vectors returns a namedtuple. until we
+            # drop support for dimod < 0.10, we have to be explicit here
+            fields = ("linear", "quadratic", "offset", "labels")
+            vec = obj.to_numpy_vectors(sort_indices=True, sort_labels=True, return_labels=True)
+            return dict(zip(fields, vec))
         elif isinstance(obj, dimod.SampleSet):
             return obj.to_serializable()
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(package_info_path, encoding='utf-8') as f:
 
 # Package requirements, minimal pinning
 install_requires = ['numpy>=1.15.0', 'networkx', 'click>5', 'plucky>=0.4.3',
-                    'dimod>=0.9.6,<0.11,!=0.10.0,!=0.10.1,!=0.10.2,!=0.10.3,!=0.10.4',
+                    'dimod>=0.9.6,<0.11,!=0.10.0,!=0.10.1,!=0.10.2,!=0.10.3,!=0.10.4,!=0.10.9',
                     # Include dwave-preprocessing, as dimod went back and forth with
                     # including it as a core dependency vs extra. Make it unbounded,
                     # as it's already constrained by dimod (if required).

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1061,10 +1061,11 @@ class TestLog(unittest.TestCase):
 
     @parameterized.expand([
         (queue.Queue(), ),
-        (queue.SimpleQueue(), ),
         (queue.LifoQueue(), ),
         (multiprocessing.Queue(), ),
-    ])
+    ] + ([
+        (queue.SimpleQueue(), ),    # unavailable in py36 and before
+    ] if hasattr(queue, 'SimpleQueue') else []))
     def test_shared_memo_queue(self, memo):
         # queue as shared, thread-safe, log record store
         key = operator.attrgetter('x')

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -22,13 +22,16 @@ import operator
 import copy
 import tempfile
 import logging
+import queue
+import multiprocessing
 from concurrent import futures
 from functools import partial
 
 import dimod
+from parameterized.parameterized import parameterized
 
 from hybrid.flow import (
-    Branch, Branches, RacingBranches, ParallelBranches,
+    Branch, Branches, RacingBranches, ParallelBranches, Parallel,
     ArgMin, Map, Reduce, Lambda, Unwind, TrackMin,
     LoopUntilNoImprovement, LoopWhileNoImprovement, SimpleIterator, Loop,
     Identity, BlockingIdentity, Dup, Const, Wait, Log
@@ -1008,6 +1011,10 @@ class TestConst(unittest.TestCase):
 
 class TestLog(unittest.TestCase):
 
+    class Inc(Runnable):
+        def next(self, state):
+            return state.updated(x=state.x + 1)
+
     def test_log_output(self):
         with tempfile.TemporaryFile(mode='w+t') as fp:
             tag = 'test'
@@ -1027,11 +1034,7 @@ class TestLog(unittest.TestCase):
             self.assertEqual(record['tag'], tag)
 
     def test_memo_in_a_loop(self):
-        class Inc(Runnable):
-            def next(self, state):
-                return state.updated(x=state.x + 1)
-
-        inc = Inc()
+        inc = TestLog.Inc()
         log = Log(key=lambda state: state.x, memo=True)
         wrk = Loop(inc | log, max_iter=3)
         inp = State(x=0)
@@ -1039,6 +1042,54 @@ class TestLog(unittest.TestCase):
 
         self.assertEqual(len(log.records), 3)
         self.assertEqual([r['data'] for r in log.records], [1, 2, 3])
+
+    def test_shared_memo_list(self):
+        # list as shared, thread-safe, log record store
+        memo = []
+        key = operator.attrgetter('x')
+        log1 = Log(key=key, memo=memo, extra=dict(id=1))
+        log2 = Log(key=key, memo=memo, extra=dict(id=2))
+        log3 = Log(key=key, memo=memo, extra=dict(id=3))
+        inc = TestLog.Inc()
+        wrk = log1 | inc | Parallel(log2, inc | log3)
+        inp = State(x=1)
+        out = wrk.run(inp).result()
+
+        self.assertEqual(len(memo), 3)
+        self.assertEqual({r['id'] for r in memo}, {1, 2, 3})
+        self.assertEqual({r['data'] for r in memo}, {1, 2, 3})
+
+    @parameterized.expand([
+        (queue.Queue(), ),
+        (queue.SimpleQueue(), ),
+        (queue.LifoQueue(), ),
+        (multiprocessing.Queue(), ),
+    ])
+    def test_shared_memo_queue(self, memo):
+        # queue as shared, thread-safe, log record store
+        key = operator.attrgetter('x')
+        log1 = Log(key=key, memo=memo, extra=dict(id=1))
+        log2 = Log(key=key, memo=memo, extra=dict(id=2))
+        log3 = Log(key=key, memo=memo, extra=dict(id=3))
+        inc = TestLog.Inc()
+        wrk = log1 | inc | Parallel(log2, inc | log3)
+        inp = State(x=1)
+        out = wrk.run(inp).result()
+
+        res = []
+        while True:
+            try:
+                res.append(memo.get_nowait())
+            except queue.Empty:
+                break
+
+        self.assertEqual(len(res), 3)
+        self.assertEqual({r['id'] for r in res}, {1, 2, 3})
+        self.assertEqual({r['data'] for r in res}, {1, 2, 3})
+
+    def test_input_validation(self):
+        with self.assertRaises(TypeError):
+            Log(key=1)
 
     def test_logging(self):
         log = Log(key=lambda state: state.x, loglevel=logging.INFO)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -296,8 +296,8 @@ class TestOceanJSONEncoder(unittest.TestCase):
     def test_bqm_encode(self):
         bqm = dimod.BQM.from_ising({'a': 1}, {'bc': 1})
         np_vec = {
-            "linear_biases": [1.0, 0.0, 0.0],
-            "quadratic": [[2], [1], [1.0]],
+            "linear": [1.0, 0.0, 0.0],
+            "quadratic": [[1], [2], [1.0]],
             "offset": 0.0,
             "labels": ["a", "b", "c"]
         }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,7 @@ from parameterized import parameterized
 
 import dimod
 import dwave_networkx as dnx
+from dwave.cloud.utils import utcnow
 
 from hybrid.core import SampleSet
 from hybrid.utils import (
@@ -284,6 +285,13 @@ class TestNumpyJSONEncoder(unittest.TestCase):
 
 
 class TestOceanJSONEncoder(unittest.TestCase):
+
+    def test_datetime(self):
+        dt = utcnow()
+        self.assertEqual(
+            json.dumps(dt, cls=OceanEncoder),
+            json.dumps(dt.isoformat())
+        )
 
     def test_bqm_encode(self):
         bqm = dimod.BQM.from_ising({'a': 1}, {'bc': 1})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,7 +24,7 @@ import dwave_networkx as dnx
 from hybrid.core import SampleSet
 from hybrid.utils import (
     chimera_tiles, flip_energy_gains, select_localsearch_adversaries,
-    hstack_samplesets, NumpyEncoder)
+    hstack_samplesets, NumpyEncoder, OceanEncoder)
 
 
 class TestEnergyFlipGainUtils(unittest.TestCase):
@@ -280,4 +280,27 @@ class TestNumpyJSONEncoder(unittest.TestCase):
         self.assertEqual(
             json.dumps(py_val),
             json.dumps(np_val, cls=NumpyEncoder)
+        )
+
+
+class TestOceanJSONEncoder(unittest.TestCase):
+
+    def test_bqm_encode(self):
+        bqm = dimod.BQM.from_ising({'a': 1}, {'bc': 1})
+        np_vec = {
+            "linear_biases": [1.0, 0.0, 0.0],
+            "quadratic": [[2], [1], [1.0]],
+            "offset": 0.0,
+            "labels": ["a", "b", "c"]
+        }
+        self.assertEqual(
+            json.dumps(bqm, cls=OceanEncoder),
+            json.dumps(np_vec)
+        )
+
+    def test_sampleset_encode(self):
+        ss = dimod.SampleSet.from_samples([1, 0, 1], 'BINARY', 0)
+        self.assertEqual(
+            json.dumps(ss, cls=OceanEncoder),
+            json.dumps(ss.to_serializable())
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,8 +258,11 @@ class TestNumpyJSONEncoder(unittest.TestCase):
         (numpy.half(1.0), 1.0), (numpy.float16(1.0), 1.0),
         (numpy.single(1.0), 1.0), (numpy.float32(1.0), 1.0),
         (numpy.double(1.0), 1.0), (numpy.float64(1.0), 1.0),
-        (numpy.longdouble(1.0), 1.0), (numpy.float128(1.0), 1.0),
-    ])
+        (numpy.longdouble(1.0), 1.0)
+    ] + ([
+        (numpy.float128(1.0), 1.0)      # unavailable on windows
+    ] if hasattr(numpy, 'float128') else [
+    ]))
     def test_numpy_primary_type_encode(self, np_val, py_val):
         self.assertEqual(
             json.dumps(py_val),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import unittest
 
 import numpy
+from parameterized import parameterized
 
 import dimod
 import dwave_networkx as dnx
@@ -22,7 +24,7 @@ import dwave_networkx as dnx
 from hybrid.core import SampleSet
 from hybrid.utils import (
     chimera_tiles, flip_energy_gains, select_localsearch_adversaries,
-    hstack_samplesets)
+    hstack_samplesets, NumpyEncoder)
 
 
 class TestEnergyFlipGainUtils(unittest.TestCase):
@@ -236,3 +238,46 @@ class TestSampleSetUtils(unittest.TestCase):
         res = hstack_samplesets(ss, bqm=bqm)
         self.assertEqual(res.vartype, dimod.SPIN)
         numpy.testing.assert_array_equal(res.record.energy, numpy.array([-1]))
+
+
+class TestNumpyJSONEncoder(unittest.TestCase):
+
+    @parameterized.expand([
+        (numpy.bool_(1), True), (numpy.bool8(1), True),
+        (numpy.byte(1), 1), (numpy.int8(1), 1),
+        (numpy.ubyte(1), 1), (numpy.uint8(1), 1),
+        (numpy.short(1), 1), (numpy.int16(1), 1),
+        (numpy.ushort(1), 1), (numpy.uint16(1), 1),
+        (numpy.intc(1), 1), (numpy.int32(1), 1),
+        (numpy.uintc(1), 1), (numpy.uint32(1), 1),
+        (numpy.int_(1), 1), (numpy.int32(1), 1),
+        (numpy.uint(1), 1), (numpy.uint32(1), 1),
+        (numpy.longlong(1), 1), (numpy.int64(1), 1),
+        (numpy.ulonglong(1), 1), (numpy.uint64(1), 1),
+        (numpy.half(1.0), 1.0), (numpy.float16(1.0), 1.0),
+        (numpy.single(1.0), 1.0), (numpy.float32(1.0), 1.0),
+        (numpy.double(1.0), 1.0), (numpy.float64(1.0), 1.0),
+        (numpy.longdouble(1.0), 1.0), (numpy.float128(1.0), 1.0),
+    ])
+    def test_numpy_primary_type_encode(self, np_val, py_val):
+        self.assertEqual(
+            json.dumps(py_val),
+            json.dumps(np_val, cls=NumpyEncoder)
+        )
+
+    @parameterized.expand([
+        (numpy.array([1, 2, 3], dtype=numpy.int), [1, 2, 3]),
+        (numpy.array([[1], [2], [3]], dtype=numpy.double), [[1.0], [2.0], [3.0]]),
+        (numpy.zeros((2, 2), dtype=numpy.bool_), [[False, False], [False, False]]),
+        (numpy.array([('Rex', 9, 81.0), ('Fido', 3, 27.0)],
+                     dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')]),
+         [['Rex', 9, 81.0], ['Fido', 3, 27.0]]),
+        (numpy.rec.array([(1, 2., 'Hello'), (2, 3., "World")],
+                         dtype=[('foo', 'i4'), ('bar', 'f4'), ('baz', 'U10')]),
+         [[1, 2.0, "Hello"], [2, 3.0, "World"]])
+    ])
+    def test_numpy_array_encode(self, np_val, py_val):
+        self.assertEqual(
+            json.dumps(py_val),
+            json.dumps(np_val, cls=NumpyEncoder)
+        )


### PR DESCRIPTION
Added `hybrid.Log` to support logging of user-specified state metrics to a file, in a memory (shared) container, or the standard python logger.