### PR TITLE
Drop dimod 0.8.x support and fix CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     parameters:
       python-version:
         type: string
-      dimod-version:
+      pip-constraints:
         type: string
 
     docker:
@@ -30,16 +30,6 @@ jobs:
             pip install -r requirements.txt -r tests/requirements.txt
             pip install wheel twine
 
-      - run:
-          name: Install appropriate dimod version
-          command: |
-            . env/bin/activate
-            if [[ "<< parameters.dimod-version >>" ]]; then
-              pip install 'dimod<< parameters.dimod-version >>'
-            else
-              pip uninstall dimod -y
-            fi
-
       - save_cache: &save-cache-env
           key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "tests/requirements.txt" }}-{{ .Environment.CIRCLE_JOB }}
           paths:
@@ -49,9 +39,11 @@ jobs:
           name: Build package
           command: env/bin/python setup.py sdist bdist_wheel
 
-      - run: &install-package
-          name: Install package
-          command: env/bin/pip install .
+      - run: &install-package-with-constraints
+          name: Install package (with constraints)
+          command: |
+            . env/bin/activate
+            pip install . -c <(printf '%s\n' << parameters.pip-constraints >>)
 
       - run: &run-python-tests
           name: Run Python tests
@@ -109,7 +101,9 @@ jobs:
 
       - save_cache: *save-cache-env
 
-      - run: *install-package
+      - run: &install-package
+          name: Install package
+          command: env/bin/pip install .
 
       - run: *run-python-tests
 
@@ -188,17 +182,20 @@ workflows:
   test:
     jobs:
       - test-linux:
-          name: test-linux-py<< matrix.python-version >><<# matrix.dimod-version >>-dimod<< matrix.dimod-version >><</ matrix.dimod-version >>
+          name: test-linux-<< matrix.python-version >> | << matrix.pip-constraints >>
           matrix:
             parameters:
               python-version: &python-versions ["3.6.12", "3.7.9", "3.8.6", "3.9.0"]
-              dimod-version: ["==0.9.6", "~=0.9.0", "~=0.10.0,>0.10.4"]
+              pip-constraints:
+                - "dimod==0.9.6 dwave-system==0.9.7"
+                - "dimod~=0.9.0 dwave-system~=1.0"
+                - "dimod~=0.10.0 dwave-system~=1.0"
             exclude:
               - python-version: "3.9.0"
-                dimod-version: "==0.9.0"    # py39 not supported until 0.9.11
+                pip-constraints: "dimod==0.9.6 dwave-system==0.9.7"    # py39 not supported until dimod==0.9.11
 
       - test-macos:
-          name: test-macos-py<< matrix.python-version >>
+          name: test-macos-<< matrix.python-version >>
           matrix:
             parameters:
               python-version: *python-versions

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ workflows:
           matrix:
             parameters:
               python-version: &python-versions ["3.6.12", "3.7.9", "3.8.6", "3.9.0"]
-              dimod-version: ["==0.9.0", "~=0.9.0", "~=0.10.0,>0.10.4"]
+              dimod-version: ["==0.9.6", "~=0.9.0", "~=0.10.0,>0.10.4"]
             exclude:
               - python-version: "3.9.0"
                 dimod-version: "==0.9.0"    # py39 not supported until 0.9.11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,10 @@ workflows:
           matrix:
             parameters:
               python-version: &python-versions ["3.6.12", "3.7.9", "3.8.6", "3.9.0"]
-              dimod-version: ["~=0.8.0,>=0.8.11", "~=0.9.0", "~=0.10.0,>0.10.4"]
+              dimod-version: ["==0.9.0", "~=0.9.0", "~=0.10.0,>0.10.4"]
+            exclude:
+              - python-version: "3.9.0"
+                dimod-version: "==0.9.0"    # py39 not supported until 0.9.11
 
       - test-macos:
           name: test-macos-py<< matrix.python-version >>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
-dimod==0.10.6
+dimod==0.10.10
 numpy>=1.19.4
 minorminer==0.2.6
-dwave-system==1.8.0
+dwave-system==1.10.0
 dwave-neal==0.5.8
 dwave-tabu==0.4.2
 dwave-greedy==0.2.1
-dwave-preprocessing~=0.3.0
+dwave-preprocessing==0.3.2
 networkx
-dwave-networkx==0.8.9
+dwave-networkx==0.8.10
 click
 plucky>=0.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ dwave-system==1.8.0
 dwave-neal==0.5.8
 dwave-tabu==0.4.2
 dwave-greedy==0.2.1
+dwave-preprocessing~=0.3.0
 networkx
 dwave-networkx==0.8.9
 click

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(package_info_path, encoding='utf-8') as f:
 
 # Package requirements, minimal pinning
 install_requires = ['numpy>=1.15.0', 'networkx', 'click>5', 'plucky>=0.4.3',
-                    'dimod>=0.8.11,<0.11,!=0.10.0,!=0.10.1,!=0.10.2,!=0.10.3,!=0.10.4',
+                    'dimod>=0.9.0,<0.11,!=0.10.0,!=0.10.1,!=0.10.2,!=0.10.3,!=0.10.4',
                     'minorminer>=0.1.7', 'dwave-networkx>=0.6.6', 'dwave-system>=0.7.6',
                     'dwave-neal>=0.5.1', 'dwave-tabu>=0.2.0', 'dwave-greedy>=0.1.0']
 

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,13 @@ with open(package_info_path, encoding='utf-8') as f:
 
 # Package requirements, minimal pinning
 install_requires = ['numpy>=1.15.0', 'networkx', 'click>5', 'plucky>=0.4.3',
-                    'dimod>=0.9.0,<0.11,!=0.10.0,!=0.10.1,!=0.10.2,!=0.10.3,!=0.10.4',
-                    'minorminer>=0.1.7', 'dwave-networkx>=0.6.6', 'dwave-system>=0.7.6',
-                    'dwave-neal>=0.5.1', 'dwave-tabu>=0.2.0', 'dwave-greedy>=0.1.0']
+                    'dimod>=0.9.6,<0.11,!=0.10.0,!=0.10.1,!=0.10.2,!=0.10.3,!=0.10.4',
+                    # Include dwave-preprocessing, as dimod went back and forth with
+                    # including it as a core dependency vs extra. Make it unbounded,
+                    # as it's already constrained by dimod (if required).
+                    'dwave-preprocessing',
+                    'minorminer>=0.1.7', 'dwave-networkx>=0.8.8', 'dwave-system>=0.7.6',
+                    'dwave-neal>=0.5.4', 'dwave-tabu>=0.2.0', 'dwave-greedy>=0.1.0']
 
 # Package extras requirements
 extras_require = {


### PR DESCRIPTION
Support `dimod>=0.9.6` and make dependency versions consistent.

Fix CI to correctly sweep supported versions of dependencies. Close #258.