### PR TITLE
Features/reference example

### DIFF
--- a/docs/reference/reference.rst
+++ b/docs/reference/reference.rst
@@ -37,5 +37,3 @@ latticeLNLS
 
 .. automodule:: hybrid.reference.latticeLNLS
    :members:
-
-      

--- a/docs/reference/reference.rst
+++ b/docs/reference/reference.rst
@@ -31,3 +31,11 @@ qbsolv
 
 .. automodule:: hybrid.reference.qbsolv
    :members:
+
+latticeLNLS
+===========
+
+.. automodule:: hybrid.reference.latticeLNLS
+   :members:
+
+      

--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -1038,7 +1038,7 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
         raise ValueError('Unsupported combination of lattice_type '
                          'and qpu_sampler topology')
     
-    if allow_unyielded_edges:
+    if allow_unyielded_edges == False:
         origin_embedding = _yield_limited_origin_embedding(origin_embedding,
                                                            proposed_source,
                                                            target)

--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -1042,6 +1042,7 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
         origin_embedding = _yield_limited_origin_embedding(origin_embedding,
                                                            proposed_source,
                                                            target)
+        
 
     if qpu_type == lattice_type:
         # Convert keys to standard vector scheme:

--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -447,7 +447,7 @@ class SublatticeDecomposer(traits.ProblemDecomposer, traits.SISO, Runnable):
     If ``problem_dims`` is a state field, geometrically offset variables are
     wrapped around boundaries according to assumed periodic boundary condition.
     This is a required field when the ``geometric_offset`` is not specified.
-    Note that, the origin embedding must specify a lattice smaller than the 
+    Note that, the origin embedding must specify a lattice smaller than the
     target lattice.
 
     Args:
@@ -457,17 +457,17 @@ class SublatticeDecomposer(traits.ProblemDecomposer, traits.SISO, Runnable):
     Returns:
         ``subproblem`` and ``embedding`` state fields
 
-
     See also:
         :class:`~hybrid.reference.lattice_lnls.LatticeLNLS`
-    
+
         :class:`~hybrid.reference.lattice_lnls.LatticeLNLSSampler`
 
         :class:`~hybrid.decomposers.make_origin_embeddings`
-        
+
         :ref:`decomposers-examples`
 
-        [REFERENCE PAPER IN PREPARATION]
+        Jack Raymond et al, `Hybrid quantum annealing for larger-than-QPU
+        lattice-structured problems <https://arxiv.org/abs/2202.03044>`_
     """
 
     def __init__(self, seed=None, **runopts):
@@ -514,7 +514,7 @@ class SublatticeDecomposer(traits.ProblemDecomposer, traits.SISO, Runnable):
                     final_coordinates[idx] += val
             return tuple(final_coordinates)
 
-        # For now we explicitely encode different automorphism as different
+        # For now we explicitly encode different automorphism as different
         # origin_embeddings, but is would be natural to allow symmetry
         # operations (automorphisms) with respect to some fixed embedding
         # and lattice class.
@@ -830,20 +830,20 @@ def _make_cubic_lattice(dimensions):
 
 
 def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
-                           problem_dims = None, reject_small_problems = True,
-                           allow_unyielded_edges = False):
+                           problem_dims=None, reject_small_problems=True,
+                           allow_unyielded_edges=False):
     """Creates optimal embeddings for a lattice.
 
-    An embedding is a dictionary specifying the mapping from each lattice 
-    variable to a set of qubits (chain). The embeddings created are compatible 
-    with the topology and shape of a specified ``qpu_sampler``. 
+    An embedding is a dictionary specifying the mapping from each lattice
+    variable to a set of qubits (chain). The embeddings created are compatible
+    with the topology and shape of a specified ``qpu_sampler``.
 
     Args:
         qpu_sampler (:class:`dimod.Sampler`, optional):
             Quantum sampler such as a D-Wave system. If not specified, the
-            :class:`~dwave.system.samplers.DWaveSampler` sampler class is used 
+            :class:`~dwave.system.samplers.DWaveSampler` sampler class is used
             to select a QPU solver with a topology compatible with the specified
-            ``lattice_type`` (e.g. an Advantage system for a 'pegasus' lattice 
+            ``lattice_type`` (e.g. an Advantage system for a 'pegasus' lattice
             type).
 
         lattice_type (str, optional, default=qpu_sampler.properties['topology']['type']):
@@ -864,18 +864,23 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
                     If ``qpu_sampler`` topology type is 'chimera', maximum
                     scale chimera subgraphs are embedded using the chimera
                     vector labeling scheme for variables.
-        
+
         problem_dims (tuple of ints, optional):
             origin_embeddings over the solver are constrained to not exceed
-            these dimensions.  
+            these dimensions.
+
             For cubic lattices, dimension bounds are specified as (x, y, z).
+
             For pegasus lattices, bounds are specified in nice coordinate
             (t, y, x, u, k): a P16 solver has bounds (3,15,15,2,4)
+
             For chimera lattices, bounds are specified in chimera coordinates
             (i,j,u,k): a C16 solver has bounds (16,16,2,4).
+
             Where embedded variables exceed these bounds the embedding is
             either truncated, or raises an error, according to the flag
-            ``reject_small_problems``
+            ``reject_small_problems``.
+
             Note that when the embedding scale exactly matches the problem
             scale, problems can also occur for the case of periodic boundary
             conditions that are not supported by these embeddings, which assume
@@ -886,8 +891,7 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
             allowed by the origin embeddings, raise an error.
             Since these routines are intended to support workflows beyond
             solvable scale, a user override is required for the inappopriate
-            use case. This flag is only invoked if problem_dims is
-            specified.
+            use case. This flag is only invoked if problem_dims is specified.
 
         allow_unyielded_edges (bool, optional, False):
             A requirement for certain sublattice based methods is that any two
@@ -917,12 +921,13 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
 
     See also:
         :class:`~hybrid.reference.lattice_lnls.LatticeLNLS`
-    
+
         :class:`~hybrid.reference.lattice_lnls.LatticeLNLSSampler`
 
         :class:`~hybrid.decomposers.SublatticeDecomposer`
-        
-        [REFERENCE PAPER IN PREPARATION]
+
+        Jack Raymond et al, `Hybrid quantum annealing for larger-than-QPU
+        lattice-structured problems <https://arxiv.org/abs/2202.03044>`_
     """
     if qpu_sampler is None:
         if lattice_type == 'pegasus' or lattice_type == 'chimera':
@@ -955,7 +960,6 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
         if lattice_type == 'pegasus':
             # Trimming to nice_coordinate supported embeddings is not a unique,
             # options, it has some advantages and some disadvantages:
-            
             proposed_source = dnx.pegasus_graph(qpu_shape[0], nice_coordinates=True)
             proposed_source = nx.relabel_nodes(
                 proposed_source,
@@ -1037,12 +1041,11 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
     else:
         raise ValueError('Unsupported combination of lattice_type '
                          'and qpu_sampler topology')
-    
-    if allow_unyielded_edges == False:
+
+    if not allow_unyielded_edges:
         origin_embedding = _yield_limited_origin_embedding(origin_embedding,
                                                            proposed_source,
                                                            target)
-        
 
     if qpu_type == lattice_type:
         # Convert keys to standard vector scheme:
@@ -1051,7 +1054,7 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
     else:
         # Keys are already in geometric format:
         pass
-    
+
     # We can propose additional embeddings. Or we can use symmetries of the
     # target graph (automorphisms), to create additional embedding options.
     # This is important in the cubic case, because the subregion shape and
@@ -1090,8 +1093,8 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
             rem_list = {key for key in origin_embedding
                         if any(key[idx]>=problem_dims[idx]
                                for idx in range(problem_dim_spec))}
-            
-            if len(rem_list)>0:
+
+            if len(rem_list) > 0:
                 if reject_small_problems:
                     raise ValueError('embedding scale exceeds '
                                      'that of the problem target (problem_dims)')

--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -879,13 +879,22 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None):
     qpu_shape = qpu_sampler.properties['topology']['shape']
 
     target = nx.Graph()
-    target.add_edges_from(qpu_sampler.edgelist)
-
+    # 'couplers' and 'qubits' property fields are preferred to
+    # edgelist and nodelist properties when available.
+    # Mutability of the former is a useful feature for masking
+    # on the fly.
+    if 'couplers' in qpu_sampler.properties:
+        target.add_edges_from(qpu_sampler.properties['couplers'])
+    else:
+        target.add_edges_from(qpu_sampler.edgelist)
     if qpu_type == lattice_type:
         # Fully yielded fully utilized native topology problem.
         # This method is also easily adapted to work for any chain-length 1
         # embedding
-        origin_embedding = {q: [q] for q in qpu_sampler.properties['qubits']}
+        if 'qubits' in qpu_sampler.properties:
+            origin_embedding = {q: [q] for q in qpu_sampler.properties['qubits']}
+        else:
+            origin_embedding = {q: [q] for q in qpu_sampler.nodelist}
         if lattice_type == 'pegasus':
             # Trimming to nice_coordinate supported embeddings is not a unique,
             # options, it has some advantages and some disadvantages:

--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -459,15 +459,15 @@ class SublatticeDecomposer(traits.ProblemDecomposer, traits.SISO, Runnable):
 
 
     See also:
-        :class:`~hybrid.reference.latticeLNLS.LatticeLNLS`
+        :class:`~hybrid.reference.lattice_lnls.LatticeLNLS`
     
-        :class:`~hybrid.reference.latticeLNLS.LatticeLNLSSampler`
+        :class:`~hybrid.reference.lattice_lnls.LatticeLNLSSampler`
 
         :class:`~hybrid.decomposers.make_origin_embeddings`
         
-        [REFERENCE PAPER IN PREPARATION]
-
         :ref:`decomposers-examples`
+
+        [REFERENCE PAPER IN PREPARATION]
     """
 
     def __init__(self, seed=None, **runopts):
@@ -904,9 +904,9 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None, problem_dims = N
         ...                                     lattice_type='cubic')  # doctest: +SKIP
 
     See also:
-        :class:`~hybrid.reference.latticeLNLS.LatticeLNLS`
+        :class:`~hybrid.reference.lattice_lnls.LatticeLNLS`
     
-        :class:`~hybrid.reference.latticeLNLS.LatticeLNLSSampler`
+        :class:`~hybrid.reference.lattice_lnls.LatticeLNLSSampler`
 
         :class:`~hybrid.decomposers.SublatticeDecomposer`
         

--- a/hybrid/reference/__init__.py
+++ b/hybrid/reference/__init__.py
@@ -15,4 +15,4 @@ from hybrid.reference.kerberos import *
 from hybrid.reference.pt import *
 from hybrid.reference.pa import *
 from hybrid.reference.qbsolv import *
-from hybrid.reference.latticeLNLS import *
+from hybrid.reference.lattice_lnls import *

--- a/hybrid/reference/__init__.py
+++ b/hybrid/reference/__init__.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 from hybrid.reference.kerberos import *
 from hybrid.reference.pt import *
 from hybrid.reference.pa import *
 from hybrid.reference.qbsolv import *
+from hybrid.reference.latticeLNLS import *

--- a/hybrid/reference/latticeLNLS.py
+++ b/hybrid/reference/latticeLNLS.py
@@ -1,0 +1,287 @@
+# Copyright 2022 D-Wave Systems Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""Greedy large neighborhood local search workflows for lattices."""
+
+import hybrid
+import dimod
+from dwave.system import DWaveSampler
+
+__all__ = ['LatticeLNLS','LatticeLNLSSampler']
+
+def LatticeLNLS(topology,
+                problem_dims,
+                qpu_sampler=None,
+                energy_threshold=None,
+                max_iter=128,
+                max_time=None,
+                convergence=None,
+                qpu_params={'num_reads': 25, 'annealing_time': 100},
+                workflow_type = 'qpu-only'):
+    '''
+    Implements lattice workflows as described in [REFERENCE PAPER]
+
+    LatticeLNLS workflow is used by :class:`LatticeLNLSSampler`.
+    
+    Args:
+
+        topology (str): 
+            A lattice topology (e.g. 'cubic'), consistent with bqm.
+            
+            Supported values:
+            
+                'pegasus' (``qpu_sampler`` must be pegasus-structured)
+                
+                'cubic' (``qpu_sampler`` must be pegasus of chimera-structured)
+                
+                'chimera' (``qpu_sampler`` must be chimera-structured)
+
+        problem_dims: (tuple of ints) 
+            Lattice dimensions (e.g. (18,18,18))
+            
+        qpu_sampler (:class:`dimod.Sampler`, optional, default=DWaveSampler()):
+            Sampler such as a D-Wave system.
+    
+        qpu_params (dict, optional, default = {'num_reads': 25, 'annealing_time': 100}):
+            Dictionary of keyword arguments with values that will be used
+            on every call of the QPU sampler.
+    
+        workflow_type (str, optional): 
+            Supported values:
+                
+                'qpu-only': Default workflow of this paper
+                
+                'qpu+post-process': Steepest greedy descent run sequentially 
+                    with the QPU.
+
+                'qpu+parallel-process': Steepest greedy descent is run in parallel
+                    with the QPU, and best result is accepted (in effect, delayed
+                    post-processing in parallel with QPU.
+
+        max_iter (int, optional, default=128):
+            Number of iterations in the hybrid algorithm.
+
+        max_time (float/None, optional):
+            Wall clock runtime termination criterion. Unlimited by default.
+
+        convergence (int, optional):
+            Number of iterations with no improvement that terminates sampling.
+
+        energy_threshold (float, optional):
+            Terminate when this energy threshold is surpassed. Check is
+            performed at the end of each iteration.
+
+    Returns:
+        Workflow (:class:`~hybrid.core.Runnable` instance).
+        
+    See also:
+        [REFERENCE PAPER]
+
+    Examples: 
+        This example creates a workflow for a cubic lattice problem
+        using the default online pegasus-structured solver.
+    
+        
+    '''
+    if qpu_sampler is None:
+        qpu_sampler = DWaveSampler()
+    embs = hybrid.make_origin_embeddings(qpu_sampler,'cubic')
+    qpu_branch = (hybrid.decomposers.SublatticeDecomposer()
+                  | hybrid.QPUSubproblemExternalEmbeddingSampler(
+                      qpu_sampler=qpu_sampler,
+                      sampling_params=qpu_params,
+                      num_reads = qpu_params['num_reads']))
+    
+    if workflow_type == 'qpu-only':
+        per_it_runnable =  (qpu_branch| hybrid.SplatComposer())
+    elif workflow_type == 'qpu+post-process':
+        per_it_runnable = (qpu_branch
+                           | hybrid.SteepestDescentSubProblemSampler()
+                           | hybrid.SplatComposer())
+    elif workflow_type == 'qpu+parallel-process':
+        per_it_runnable = ( 
+            hybrid.Parallel(
+                qpu_branch | hybrid.SplatComposer(),
+                hybrid.SteepestDescentProblemSampler())
+            | hybrid.ArgMin())
+    else:
+        raise ValueError('Unkown workflow type')
+    if energy_threshold is not None:
+        energy_reached = lambda en: en <= energy_threshold
+    else:
+        energy_reached = None
+    #Iterate to a termination criteria, integrate proposal if energy lowered:
+    workflow = hybrid.Loop(per_it_runnable | hybrid.TrackMin(output=True),
+                           max_iter=max_iter, terminate=energy_reached,
+                           convergence=convergence, max_time=max_time)
+    return workflow 
+
+
+class LatticeLNLSSampler(dimod.Sampler):
+    """A dimod-compatible hybrid decomposition sampler for problems of lattice structure.
+
+    For workflow and lattice related arguments see: :class:`~hybrid.reference.latticeLNLS.LatticeLNLS`.
+
+
+    Examples:
+        This example solves a cubic-structured BQM using the default QPU.
+        An 18x18x18 cubic-lattice ferromagnet is created, and sampled
+        by the lattice workflow.
+
+        >>> import dimod
+        >>> import hybrid
+        >>> from dwave.system import DWaveSampler
+        >>> topology = 'cubic'
+        >>> qpu_sampler = DWaveSampler()                         # doctest: +SKIP
+        >>> sampler = hybrid.LatticeLNLSSampler()               # doctest: +SKIP
+        >>> 
+        >>> cuboid = (18,18,18)
+        >>> edge_list = ([((i,j,k),((i+1)%cuboid[0],j,k)) for i in range(cuboid[0])
+                      for j in  range(cuboid[1]) for k in range(cuboid[2])]
+                     + [((i,j,k),(i,(j+1)%cuboid[1],k)) for i in range(cuboid[0])
+                        for j in  range(cuboid[1]) for k in range(cuboid[2])]
+                     + [((i,j,k),(i,j,(k+1)%cuboid[2])) for i in range(cuboid[0])
+                        for j in range(cuboid[1]) for k in range(cuboid[2])])
+        >>> bqm = dimod.BinaryQuadraticModel.from_ising({},{e : -1 for e in edge_list})
+        >>> EGS = -len(edge_list)
+        >>> qpu_params={'num_reads': 25,
+                        'annealing_time' : 100,
+                        'auto_scale' : False,
+                        'chain_strength' : 2}
+        >>> response = sampler.sample(topology='cubic',bqm=bqm,  # doctest: +SKIP
+                                      problem_dims=cuboid,                             # doctest: +SKIP
+                                      energy_threshold=EGS,                            # doctest: +SKIP
+                                      qpu_sampler=qpu_sampler,
+                                      qpu_params=qpu_params)                           # doctest: +SKIP
+        >>> response.data_vectors['energy']                      # doctest: +SKIP
+        array([-17496]) 
+    """
+
+    properties = None
+    parameters = None
+    runnable = None
+    origin_embedding = None
+    def __init__(self):
+        #Minimum requirements for dimod compatibility are used.
+        #Certain parameters might be initialized in principle and
+        #shared amongst many sampling processes.
+        self.parameters = {
+            'origin_embeddings':None
+        }
+        self.properties = {}
+
+    def sample(self, topology, bqm, problem_dims, qpu_sampler=None, init_sample=None, num_reads=1, **kwargs):
+        """Solve large subspaces of a lattice structured problem sequentially 
+        integrating proposals greedily to arrive at a global or local minima of the bqm.
+
+        Args:
+        
+            bqm (:obj:`~dimod.BinaryQuadraticModel`):
+                Binary quadratic model to be sampled from. Keying of variables
+                must be appropriate to the lattice class.
+           
+            init_sample (:class:`~dimod.SampleSet`, callable, ``None``):
+                Initial sample set (or sample generator) used for each "read".
+                Use a random sample for each read by default.
+
+            num_reads (int):
+                Number of reads. Each sample is the result of a single run of the
+                hybrid algorithm.
+
+            workflow arguments: see :class:`~hybrid.reference.latticeLNLS.LatticeLNLS`.
+
+        Returns:
+            :obj:`~dimod.SampleSet`: A `dimod` :obj:`.~dimod.SampleSet` object.
+
+        """
+        if 'qpu_sampler' not in kwargs:
+            qpu_sampler = DWaveSampler()
+            kwargs['qpu_sampler'] = qpu_sampler
+        if 'energy_threshold' not in kwargs:
+            kwargs['energy_threshold'] = None
+        
+        #Recreate on each call, no reuse:
+        self.origin_embeddings = hybrid.make_origin_embeddings(qpu_sampler,'cubic')
+    
+        if callable(init_sample):
+            init_state_gen = lambda: hybrid.State.from_sample(init_sample(), bqm,
+                                                              problem_dims=problem_dims,
+                                                              origin_embeddings=self.origin_embeddings)
+        elif init_sample is None:
+            init_state_gen = lambda: hybrid.State.from_sample(hybrid.random_sample(bqm),
+                                                              bqm,
+                                                              problem_dims=problem_dims,
+                                                              origin_embeddings=self.origin_embeddings)
+        elif isinstance(init_sample, dimod.SampleSet):
+            init_state_gen = lambda: hybrid.State.from_sample(init_sample, bqm,
+                                                              problem_dims=problem_dims,
+                                                              origin_embeddings=self.origin_embeddings)
+        else:
+            raise TypeError("'init_sample' should be a SampleSet or a SampleSet generator")
+
+        #Recreate on each call, no reuse:
+        self.runnable = LatticeLNLS(topology=topology,
+                                    problem_dims=problem_dims,
+                                    **kwargs)
+
+        samples = []
+        energies = []
+        for _ in range(num_reads):
+            init_state = init_state_gen()
+            final_state = self.runnable.run(init_state)
+            # the best sample from each run is one "read"
+            ss = final_state.result().samples
+            ss.change_vartype(bqm.vartype, inplace=True)
+            samples.append(ss.first.sample)
+            energies.append(ss.first.energy)
+
+        return dimod.SampleSet.from_samples(samples, vartype=bqm.vartype, energy=energies)
+
+if __name__ == "__main__":
+    #Example is an 18x18x18 Ferromagnet solved by the default QPU
+    #sampler
+    from dwave.system import DWaveSampler
+    cuboid = (18,18,18)
+    edge_list = ([((i,j,k),((i+1)%cuboid[0],j,k)) for i in range(cuboid[0])
+                  for j in  range(cuboid[1]) for k in range(cuboid[2])]
+                 + [((i,j,k),(i,(j+1)%cuboid[1],k)) for i in range(cuboid[0])
+                    for j in  range(cuboid[1]) for k in range(cuboid[2])]
+                 + [((i,j,k),(i,j,(k+1)%cuboid[2])) for i in range(cuboid[0])
+                    for j in range(cuboid[1]) for k in range(cuboid[2])])
+    bqm = dimod.BinaryQuadraticModel.from_ising({},{e : -1 for e in edge_list})
+    qpu_params={'num_reads': 25,
+                'annealing_time' : 100,
+                'auto_scale' : False,
+                'chain_strength' : 2}
+    EGS = - len(edge_list)
+    qpu_sampler = DWaveSampler()
+    
+    workflow = LatticeLNLS(topology='cubic',
+                           problem_dims=cuboid,
+                           qpu_sampler=qpu_sampler,
+                           qpu_params=qpu_params,
+                           energy_threshold=EGS)
+
+    sampler = LatticeLNLSSampler()
+    sampleset = sampler.sample(topology='cubic',bqm=bqm,problem_dims=cuboid,energy_threshold=EGS,qpu_params=qpu_params)
+    print(sampleset)
+    embs = hybrid.make_origin_embeddings(qpu_sampler,'cubic')
+    init_state = hybrid.State.from_sample(hybrid.random_sample(bqm),
+                                          bqm,
+                                          problem_dims=cuboid,
+                                          origin_embeddings=embs)
+    final_state = workflow.run(init_state)
+    
+    

--- a/hybrid/reference/latticeLNLS.py
+++ b/hybrid/reference/latticeLNLS.py
@@ -203,7 +203,7 @@ class LatticeLNLSSampler(dimod.Sampler):
         }
         self.properties = {}
 
-    def sample(self, topology, bqm, problem_dims, exclude_dims = None, qpu_sampler=None, init_sample=None, num_reads=1, **kwargs):
+    def sample(self, topology, bqm, problem_dims, exclude_dims = None, reject_small_problems = True, qpu_sampler=None, init_sample=None, num_reads=1, **kwargs):
         """Solve large subspaces of a lattice structured problem sequentially 
         integrating proposals greedily to arrive at a global or local minima of the bqm.
 
@@ -235,6 +235,11 @@ class LatticeLNLSSampler(dimod.Sampler):
 
                 * 'cubic': [] all dimensions are dispaced.
 
+            reject_small_problems (bool, optional, default=True):
+                If the subsolver is bigger than the target problem, raise an error by
+                default (True), otherwise quietly shrink the embedding to be no larger 
+                than the target problem.
+
             additional workflow arguments:
                 per :class:`~hybrid.reference.latticeLNLS.LatticeLNLS`.
 
@@ -261,7 +266,9 @@ class LatticeLNLSSampler(dimod.Sampler):
             else:
                 exclude_dims = []
                 #Recreate on each call, no reuse:
-        self.origin_embeddings = hybrid.make_origin_embeddings(qpu_sampler,'cubic',problem_dims=problem_dims)
+        self.origin_embeddings = hybrid.make_origin_embeddings(qpu_sampler,'cubic',
+                                                               problem_dims=problem_dims,
+                                                               reject_small_problems=reject_small_problems)
     
         if callable(init_sample):
             init_state_gen = lambda: hybrid.State.from_sample(init_sample(), bqm,

--- a/hybrid/reference/latticeLNLS.py
+++ b/hybrid/reference/latticeLNLS.py
@@ -57,6 +57,9 @@ def LatticeLNLS(topology,
         qpu_params (dict, optional, default = ``{'num_reads': 25, 'annealing_time': 100}``): 
             Dictionary of keyword arguments with values that will be used
             on every call of the QPU sampler.
+            A local copy of the parameter is made. If the dictionary does not 
+            include 'num_reads', it is defaulted as 25, if dictionary
+            does not include 'annealing_time', it is defaulted as 100.
     
         workflow_type (str, optional): 
             Supported values: 
@@ -97,12 +100,18 @@ def LatticeLNLS(topology,
     '''
     if qpu_sampler is None:
         qpu_sampler = DWaveSampler()
+    qpu_params0 = qpu_params.copy()
+    if 'num_reads' not in qpu_params0:
+        qpu_params0['num_reads'] = 25
+    if 'annealing_time' not in qpu_params0:
+        qpu_params0['annealing_time'] = 100
+    
     embs = hybrid.make_origin_embeddings(qpu_sampler,'cubic')
     qpu_branch = (hybrid.decomposers.SublatticeDecomposer()
                   | hybrid.QPUSubproblemExternalEmbeddingSampler(
                       qpu_sampler=qpu_sampler,
-                      sampling_params=qpu_params,
-                      num_reads = qpu_params['num_reads']))
+                      sampling_params=qpu_params0,
+                      num_reads=qpu_params0['num_reads']))
     
     if workflow_type == 'qpu-only':
         per_it_runnable =  (qpu_branch| hybrid.SplatComposer())

--- a/hybrid/reference/latticeLNLS.py
+++ b/hybrid/reference/latticeLNLS.py
@@ -31,7 +31,7 @@ def LatticeLNLS(topology,
                 qpu_params={'num_reads': 25, 'annealing_time': 100},
                 workflow_type = 'qpu-only'):
     '''
-    Implements lattice workflows as described in [REFERENCE PAPER]
+    Implements lattice workflows as described in [REFERENCE PAPER IN PREPARATION]
 
     LatticeLNLS workflow is used by :class:`LatticeLNLSSampler`.
     
@@ -40,7 +40,7 @@ def LatticeLNLS(topology,
         topology (str): 
             A lattice topology (e.g. 'cubic'), consistent with bqm.
             
-            Supported values:
+            Supported values: 
             
                 'pegasus' (``qpu_sampler`` must be pegasus-structured)
                 
@@ -48,27 +48,27 @@ def LatticeLNLS(topology,
                 
                 'chimera' (``qpu_sampler`` must be chimera-structured)
 
-        problem_dims: (tuple of ints) 
+        problem_dims (tuple of ints): 
             Lattice dimensions (e.g. (18,18,18))
             
-        qpu_sampler (:class:`dimod.Sampler`, optional, default=DWaveSampler()):
+        qpu_sampler (:class:`dimod.Sampler`, optional, default=DWaveSampler()): 
             Sampler such as a D-Wave system.
     
-        qpu_params (dict, optional, default = {'num_reads': 25, 'annealing_time': 100}):
+        qpu_params (dict, optional, default = ``{'num_reads': 25, 'annealing_time': 100}``): 
             Dictionary of keyword arguments with values that will be used
             on every call of the QPU sampler.
     
         workflow_type (str, optional): 
-            Supported values:
+            Supported values: 
                 
-                'qpu-only': Default workflow of this paper
+               'qpu-only': Default workflow of this paper
                 
-                'qpu+post-process': Steepest greedy descent run sequentially 
-                    with the QPU.
+               'qpu+post-process': Steepest greedy descent run sequentially 
+               with the QPU.
 
-                'qpu+parallel-process': Steepest greedy descent is run in parallel
-                    with the QPU, and best result is accepted (in effect, delayed
-                    post-processing in parallel with QPU.
+               'qpu+parallel-process': Steepest greedy descent is run in parallel
+               with the QPU, and best result is accepted (in effect, delayed
+               post-processing in parallel with QPU.
 
         max_iter (int, optional, default=128):
             Number of iterations in the hybrid algorithm.
@@ -87,7 +87,7 @@ def LatticeLNLS(topology,
         Workflow (:class:`~hybrid.core.Runnable` instance).
         
     See also:
-        [REFERENCE PAPER]
+        [REFERENCE PAPER IN PREPARATION]
 
     Examples: 
         This example creates a workflow for a cubic lattice problem

--- a/hybrid/reference/lattice_lnls.py
+++ b/hybrid/reference/lattice_lnls.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 """Greedy large neighborhood local search workflows for lattices."""
 
 import hybrid
@@ -21,63 +20,64 @@ from dwave.system import DWaveSampler
 
 __all__ = ['LatticeLNLS','LatticeLNLSSampler']
 
+
 def LatticeLNLS(topology,
-                exclude_dims = [],
+                exclude_dims=None,
                 qpu_sampler=None,
                 energy_threshold=None,
                 max_iter=128,
                 max_time=None,
                 convergence=None,
-                qpu_params={'num_reads': 25, 'annealing_time': 100},
-                workflow_type = 'qpu-only'):
-    '''
-    Implements lattice workflows as described in [REFERENCE PAPER IN PREPARATION]
+                qpu_params=None,
+                workflow_type='qpu-only'):
+    '''Implements lattice workflows as described in `Hybrid quantum annealing for
+    larger-than-QPU lattice-structured problems <https://arxiv.org/abs/2202.03044>`_.
 
     LatticeLNLS workflow is used by :class:`LatticeLNLSSampler`.
-    Note that to operate this workflow a minimal set of lattice specific state 
+    Note that to operate this workflow a minimal set of lattice specific state
     variables must be instantiated:
-    
+
     1. bqm: A :obj:`~dimod.BinaryQuadraticModel`, with variables indexed geometrically
-    
+
     2. origin_embeddings: see :class:`~hybrid.decomposers.make_origin_embeddings`
-    
+
     3. problem_dims: see :class:`~hybrid.decomposers.SublatticeDecomposer`
-    
+
     Args:
 
-        topology (str): 
+        topology (str):
             A lattice topology (e.g. 'cubic'), consistent with bqm.
-            
-            Supported values: 
-            
+
+            Supported values:
+
                 * 'pegasus' (``qpu_sampler`` must be pegasus-structured)
-                
+
                 * 'cubic' (``qpu_sampler`` must be pegasus of chimera-structured)
-                
+
                 * 'chimera' (``qpu_sampler`` must be chimera-structured)
 
-        qpu_sampler (:class:`dimod.Sampler`, optional, default=DWaveSampler()): 
+        qpu_sampler (:class:`dimod.Sampler`, optional, default=DWaveSampler()):
             Sampler such as a D-Wave system.
-    
-        qpu_params (dict, optional, default = ``{'num_reads': 25, 'annealing_time': 100}``): 
+
+        qpu_params (dict, optional, default = ``{'num_reads': 25, 'annealing_time': 100}``):
             Dictionary of keyword arguments with values that will be used
             on every call of the QPU sampler.
-            A local copy of the parameter is made. If the dictionary does not 
+            A local copy of the parameter is made. If the dictionary does not
             include 'num_reads', it is defaulted as 25, if dictionary
             does not include 'annealing_time', it is defaulted as 100.
-    
-        workflow_type (str, optional): 
-            Options are: 
-                
+
+        workflow_type (str, optional):
+            Options are:
+
                * 'qpu-only'
                    Default workflow of this paper
-                
+
                * 'qpu+post-process'
-                   Steepest greedy descent over the subspace is run 
+                   Steepest greedy descent over the subspace is run
                    sequentially on samples returned by the QPU.
 
                * 'qpu+parallel-process'
-                   Steepest greedy descent on the full space is run in 
+                   Steepest greedy descent on the full space is run in
                    parallel with the QPU; the best result is accepted on
                    each iteration.
 
@@ -96,15 +96,19 @@ def LatticeLNLS(topology,
 
     Returns:
         Workflow (:class:`~hybrid.core.Runnable` instance).
-        
+
     See also:
         :class:`~hybrid.decomposers.make_origin_embeddings`
-    
+
         :class:`~hybrid.decomposers.SublatticeDecomposer`
-        
-        [REFERENCE PAPER IN PREPARATION]
-        
+
+        Jack Raymond et al, `Hybrid quantum annealing for larger-than-QPU
+        lattice-structured problems <https://arxiv.org/abs/2202.03044>`_
     '''
+    if exclude_dims is None:
+        exclude_dims = []
+    if qpu_params is None:
+        qpu_params = {'num_reads': 25, 'annealing_time': 100}
     if qpu_sampler is None:
         qpu_sampler = DWaveSampler()
     qpu_params0 = qpu_params.copy()
@@ -112,13 +116,13 @@ def LatticeLNLS(topology,
         qpu_params0['num_reads'] = 25
     if 'annealing_time' not in qpu_params0:
         qpu_params0['annealing_time'] = 100
-    
+
     qpu_branch = (hybrid.decomposers.SublatticeDecomposer()
                   | hybrid.QPUSubproblemExternalEmbeddingSampler(
                       qpu_sampler=qpu_sampler,
                       sampling_params=qpu_params0,
                       num_reads=qpu_params0['num_reads']))
-    
+
     if workflow_type == 'qpu-only':
         per_it_runnable =  (qpu_branch| hybrid.SplatComposer())
     elif workflow_type == 'qpu+post-process':
@@ -126,13 +130,13 @@ def LatticeLNLS(topology,
                            | hybrid.SteepestDescentSubProblemSampler()
                            | hybrid.SplatComposer())
     elif workflow_type == 'qpu+parallel-process':
-        per_it_runnable = ( 
+        per_it_runnable = (
             hybrid.Parallel(
                 qpu_branch | hybrid.SplatComposer(),
                 hybrid.SteepestDescentProblemSampler())
             | hybrid.ArgMin())
     else:
-        raise ValueError('Unkown workflow type')
+        raise ValueError('Unknown workflow type')
     if energy_threshold is not None:
         energy_reached = lambda en: en <= energy_threshold
     else:
@@ -141,14 +145,15 @@ def LatticeLNLS(topology,
     workflow = hybrid.Loop(per_it_runnable | hybrid.TrackMin(output=True),
                            max_iter=max_iter, terminate=energy_reached,
                            convergence=convergence, max_time=max_time)
-    return workflow 
+    return workflow
 
 
 class LatticeLNLSSampler(dimod.Sampler):
-    """A dimod-compatible hybrid decomposition sampler for problems of lattice structure.
+    """A dimod-compatible hybrid decomposition sampler for problems of lattice
+    structure.
 
-    For workflow and lattice related arguments see: :class:`~hybrid.reference.lattice_lnls.LatticeLNLS`.
-
+    For workflow and lattice related arguments, see:
+    :class:`~hybrid.reference.lattice_lnls.LatticeLNLS`.
 
     Examples:
         This example solves a cubic-structured BQM using the default QPU.
@@ -163,72 +168,73 @@ class LatticeLNLSSampler(dimod.Sampler):
         >>> sampler = hybrid.LatticeLNLSSampler()               # doctest: +SKIP
         >>> cuboid = (18,18,18)
         >>> edge_list = ([((i,j,k),((i+1)%cuboid[0],j,k)) for i in range(cuboid[0])
-                      for j in  range(cuboid[1]) for k in range(cuboid[2])]
-                     + [((i,j,k),(i,(j+1)%cuboid[1],k)) for i in range(cuboid[0])
-                        for j in  range(cuboid[1]) for k in range(cuboid[2])]
-                     + [((i,j,k),(i,j,(k+1)%cuboid[2])) for i in range(cuboid[0])
-                        for j in range(cuboid[1]) for k in range(cuboid[2])])
-        >>> bqm = dimod.BinaryQuadraticModel.from_ising({},{e : -1 for e in edge_list})
+        ...              for j in  range(cuboid[1]) for k in range(cuboid[2])]
+        ...             + [((i,j,k),(i,(j+1)%cuboid[1],k)) for i in range(cuboid[0])
+        ...                for j in  range(cuboid[1]) for k in range(cuboid[2])]
+        ...             + [((i,j,k),(i,j,(k+1)%cuboid[2])) for i in range(cuboid[0])
+        ...                for j in range(cuboid[1]) for k in range(cuboid[2])])
+        >>> bqm = dimod.BinaryQuadraticModel.from_ising({}, {e: -1 for e in edge_list})
         >>> EGS = -len(edge_list)
         >>> qpu_params={'num_reads': 25,
-                        'annealing_time' : 100,
-                        'auto_scale' : False,
-                        'chain_strength' : 2}
-        >>> response = sampler.sample(topology='cubic',bqm=bqm,  # doctest: +SKIP
-                                      problem_dims=cuboid,                             # doctest: +SKIP
-                                      energy_threshold=EGS,                            # doctest: +SKIP
-                                      qpu_sampler=qpu_sampler,
-                                      qpu_params=qpu_params)                           # doctest: +SKIP
+        ...             'annealing_time': 100,
+        ...             'auto_scale': False,
+        ...             'chain_strength': 2}
+        >>> response = sampler.sample(topology='cubic', bqm=bqm,
+        ...                           problem_dims=cuboid,
+        ...                           energy_threshold=EGS,
+        ...                           qpu_sampler=qpu_sampler,
+        ...                           qpu_params=qpu_params)                           # doctest: +SKIP
         >>> response.data_vectors['energy']                      # doctest: +SKIP
-        array([-17496]) 
+        array([-17496])
 
     See also:
         :class:`~hybrid.decomposers.make_origin_embeddings`
-    
+
         :class:`~hybrid.decomposers.SublatticeDecomposer`
-        
-        [REFERENCE PAPER IN PREPARATION]
+
+        Jack Raymond et al, `Hybrid quantum annealing for larger-than-QPU
+        lattice-structured problems <https://arxiv.org/abs/2202.03044>`_
     """
 
     properties = None
     parameters = None
     runnable = None
     origin_embedding = None
+
     def __init__(self):
         #Minimum requirements for dimod compatibility are used.
         #Certain parameters might be initialized in principle and
         #shared amongst many sampling processes.
         self.parameters = {
-            'origin_embeddings':None
+            'origin_embeddings': None
         }
         self.properties = {}
 
-    def sample(self, topology, bqm, problem_dims, exclude_dims = None,
-               reject_small_problems = True, qpu_sampler=None,
+    def sample(self, topology, bqm, problem_dims, exclude_dims=None,
+               reject_small_problems=True, qpu_sampler=None,
                init_sample=None, num_reads=1, **kwargs):
-        """Solve large subspaces of a lattice structured problem sequentially 
+        """Solve large subspaces of a lattice structured problem sequentially
         integrating proposals greedily to arrive at a global or local minima of
         the bqm.
 
         Args:
-        
-            bqm (:obj:`~dimod.BinaryQuadraticModel`):
+            bqm (:class:`~dimod.BinaryQuadraticModel`):
                 Binary quadratic model to be sampled from. Keying of variables
                 must be appropriate to the lattice class.
-           
+
             init_sample (:class:`~dimod.SampleSet`, callable, ``None``):
                 Initial sample set (or sample generator) used for each "read".
                 Use a random sample for each read by default.
 
             num_reads (int):
-                Number of reads. Each sample is the result of a single run of 
+                Number of reads. Each sample is the result of a single run of
                 the hybrid algorithm.
 
-            problem_dims (tuple of ints): 
-                Lattice dimensions (e.g. cubic case (18,18,18))
-            
+            problem_dims (tuple of ints):
+                Lattice dimensions (e.g. cubic case (18,18,18)).
+
             exclude_dims (list of ints, optional):
-                Subspaces are selected by geometric displacement. In the case of 
+                Subspaces are selected by geometric displacement. In the case of
                 cellular-level displacements only dimensions indexing cell-displacements
                 are considered. The defaults are topology dependent:
 
@@ -236,7 +242,7 @@ class LatticeLNLSSampler(dimod.Sampler):
 
                 * 'pegasus': [0,3,4] (t,u,k nice pegasus coordinates are not displaced).
 
-                * 'cubic': [] all dimensions are dispaced.
+                * 'cubic': [] all dimensions are displaced.
 
             reject_small_problems (bool, optional, default=True):
                 If the subsolver is bigger than the target problem, raise an
@@ -247,30 +253,31 @@ class LatticeLNLSSampler(dimod.Sampler):
                 per :class:`~hybrid.reference.lattice_lnls.LatticeLNLS`.
 
         Returns:
-            :obj:`~dimod.SampleSet`: A `dimod` :obj:`.~dimod.SampleSet` object.
+            :class:`~dimod.SampleSet`: A `dimod` :class:`.~dimod.SampleSet` object.
 
         See also:
             :class:`~hybrid.decomposers.make_origin_embeddings`
-    
+
             :class:`~hybrid.decomposers.SublatticeDecomposer`
-        
-            [REFERENCE PAPER IN PREPARATION]
+
+            Jack Raymond et al, `Hybrid quantum annealing for larger-than-QPU
+            lattice-structured problems <https://arxiv.org/abs/2202.03044>`_
         """
         if qpu_sampler is None:
             qpu_sampler = DWaveSampler()
-            
-        if exclude_dims == None:
-            if topology=='chimera':
+
+        if exclude_dims is None:
+            if topology == 'chimera':
                 exclude_dims = [2,3]
-            elif topology=='chimera':
+            elif topology == 'pegasus':
                 exclude_dims = [0,3,4]
             else:
                 exclude_dims = []
                 #Recreate on each call, no reuse:
-        self.origin_embeddings = hybrid.make_origin_embeddings(qpu_sampler,'cubic',
-                                                               problem_dims=problem_dims,
-                                                               reject_small_problems=reject_small_problems)
-    
+        self.origin_embeddings = hybrid.make_origin_embeddings(
+            qpu_sampler, 'cubic', problem_dims=problem_dims,
+            reject_small_problems=reject_small_problems)
+
         if callable(init_sample):
             init_state_gen = lambda: hybrid.State.from_sample(
                 init_sample(),

--- a/hybrid/reference/lattice_lnls.py
+++ b/hybrid/reference/lattice_lnls.py
@@ -256,11 +256,9 @@ class LatticeLNLSSampler(dimod.Sampler):
         
             [REFERENCE PAPER IN PREPARATION]
         """
-        if 'qpu_sampler' not in kwargs:
+        if qpu_sampler is None:
             qpu_sampler = DWaveSampler()
-            kwargs['qpu_sampler'] = qpu_sampler
-        if 'energy_threshold' not in kwargs:
-            kwargs['energy_threshold'] = None
+            
         if exclude_dims == None:
             if topology=='chimera':
                 exclude_dims = [2,3]
@@ -296,6 +294,7 @@ class LatticeLNLSSampler(dimod.Sampler):
 
         #Recreate on each call, no reuse:
         self.runnable = LatticeLNLS(topology=topology,
+                                    qpu_sampler=qpu_sampler,
                                     **kwargs)
 
         samples = []

--- a/hybrid/samplers.py
+++ b/hybrid/samplers.py
@@ -71,14 +71,14 @@ class QPUSubproblemExternalEmbeddingSampler(traits.SubproblemSampler,
             Dictionary of keyword arguments with values that will be used
             on every call of the (external-embedding-wrapped QPU) sampler.
 
-        logical_spin_rev_trans (int, optional, default=False):
+        logical_srt (int, optional, default=False):
             Perform a spin-reversal transform over the logical space.
 
     See :ref:`samplers-examples`.
     """
 
     def __init__(self, num_reads=100, qpu_sampler=None, sampling_params=None,
-                 logical_spin_rev_trans = False, **runopts):
+                 logical_srt = False, **runopts):
         super(QPUSubproblemExternalEmbeddingSampler, self).__init__(**runopts)
 
         self.num_reads = num_reads
@@ -91,7 +91,7 @@ class QPUSubproblemExternalEmbeddingSampler(traits.SubproblemSampler,
             sampling_params = {}
         self.sampling_params = sampling_params
 
-        self.logical_spin_rev_trans = logical_spin_rev_trans
+        self.logical_srt = logical_srt
         
     def __repr__(self):
         return ("{self}(num_reads={self.num_reads!r}, "
@@ -106,7 +106,7 @@ class QPUSubproblemExternalEmbeddingSampler(traits.SubproblemSampler,
         params.update(num_reads=num_reads)
 
         sampler = FixedEmbeddingComposite(self.sampler, embedding=state.embedding)
-        if logical_spin_rev_trans:
+        if logical_srt:
             params.update(num_spin_reversal_transforms=1)
             sampler = SpinReversalTransformComposite(sampler)
         response = sampler.sample(state.subproblem, **params)

--- a/hybrid/samplers.py
+++ b/hybrid/samplers.py
@@ -26,6 +26,7 @@ from collections import namedtuple
 import dimod
 from dwave.system.samplers import DWaveSampler
 from dwave.system.composites import AutoEmbeddingComposite, FixedEmbeddingComposite
+from dwave.preprocessing.composites import SpinReversalTransformComposite
 
 from tabu import TabuSampler
 from neal import SimulatedAnnealingSampler
@@ -70,15 +71,18 @@ class QPUSubproblemExternalEmbeddingSampler(traits.SubproblemSampler,
             Dictionary of keyword arguments with values that will be used
             on every call of the (external-embedding-wrapped QPU) sampler.
 
+        logical_spin_rev_trans (int, optional, default=False):
+            Perform a spin-reversal transform over the logical space.
+
     See :ref:`samplers-examples`.
     """
 
     def __init__(self, num_reads=100, qpu_sampler=None, sampling_params=None,
-                 **runopts):
+                 logical_spin_rev_trans = False, **runopts):
         super(QPUSubproblemExternalEmbeddingSampler, self).__init__(**runopts)
 
         self.num_reads = num_reads
-
+        
         if qpu_sampler is None:
             qpu_sampler = DWaveSampler()
         self.sampler = qpu_sampler
@@ -87,6 +91,8 @@ class QPUSubproblemExternalEmbeddingSampler(traits.SubproblemSampler,
             sampling_params = {}
         self.sampling_params = sampling_params
 
+        self.logical_spin_rev_trans = logical_spin_rev_trans
+        
     def __repr__(self):
         return ("{self}(num_reads={self.num_reads!r}, "
                        "qpu_sampler={self.sampler!r}, "
@@ -100,6 +106,9 @@ class QPUSubproblemExternalEmbeddingSampler(traits.SubproblemSampler,
         params.update(num_reads=num_reads)
 
         sampler = FixedEmbeddingComposite(self.sampler, embedding=state.embedding)
+        if logical_spin_rev_trans:
+            params.update(num_spin_reversal_transforms=1)
+            sampler = SpinReversalTransformComposite(sampler)
         response = sampler.sample(state.subproblem, **params)
 
         return state.updated(subsamples=response)

--- a/hybrid/samplers.py
+++ b/hybrid/samplers.py
@@ -106,7 +106,7 @@ class QPUSubproblemExternalEmbeddingSampler(traits.SubproblemSampler,
         params.update(num_reads=num_reads)
 
         sampler = FixedEmbeddingComposite(self.sampler, embedding=state.embedding)
-        if logical_srt:
+        if self.logical_srt:
             params.update(num_spin_reversal_transforms=1)
             sampler = SpinReversalTransformComposite(sampler)
         response = sampler.sample(state.subproblem, **params)

--- a/hybrid/samplers.py
+++ b/hybrid/samplers.py
@@ -78,11 +78,11 @@ class QPUSubproblemExternalEmbeddingSampler(traits.SubproblemSampler,
     """
 
     def __init__(self, num_reads=100, qpu_sampler=None, sampling_params=None,
-                 logical_srt = False, **runopts):
+                 logical_srt=False, **runopts):
         super(QPUSubproblemExternalEmbeddingSampler, self).__init__(**runopts)
 
         self.num_reads = num_reads
-        
+
         if qpu_sampler is None:
             qpu_sampler = DWaveSampler()
         self.sampler = qpu_sampler
@@ -92,7 +92,7 @@ class QPUSubproblemExternalEmbeddingSampler(traits.SubproblemSampler,
         self.sampling_params = sampling_params
 
         self.logical_srt = logical_srt
-        
+
     def __repr__(self):
         return ("{self}(num_reads={self.num_reads!r}, "
                        "qpu_sampler={self.sampler!r}, "

--- a/tests/test_decomposers.py
+++ b/tests/test_decomposers.py
@@ -836,6 +836,5 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
                                                    reject_small_problems=False)
                 for orig_emb in orig_embs:
                     from numpy import prod
-                    print(cs,prod(cs),len(orig_emb))
                     self.assertTrue(len(orig_emb)==prod(cs))
                     self.assertFalse(any(any(key[idx] >= bound for idx,bound in enumerate(cs)) for key in orig_emb))

--- a/tests/test_decomposers.py
+++ b/tests/test_decomposers.py
@@ -670,6 +670,7 @@ class TestRoofDualityDecomposer(unittest.TestCase):
                          bqm.energies((new.samples.record.sample,
                                        new.samples.variables)))
 
+
 class MockDWaveSamplerGeneralization(MockDWaveSampler):
     """Extend the `dwave.system.testing.MockDWaveSampler` to Pegasus topology.
     
@@ -774,7 +775,6 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
                         for key, val in orig_emb.items():
                             self.assertEqual(len(key), tuple_length)
                             self.assertEqual(len(val), chain_length)
-
         
     def test_all_embeddings_validity(self):
         """Check that embeddings are valid for supported lattice_types.

--- a/tests/test_decomposers.py
+++ b/tests/test_decomposers.py
@@ -813,7 +813,7 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
                         source=proposed_source.subgraph(list(orig_emb.keys())),
                         target=qpu_sampler.properties['couplers']))
 
-    def test_all_embeddings_validity(self):
+    def test_constrained_validity(self):
         """Check that we can constrain an embedding to a given subspace
         """
         # Full scale is 16, a smaller default is used
@@ -835,6 +835,7 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
                                                    problem_dims=cs,
                                                    reject_small_problems=False)
                 for orig_emb in orig_embs:
-                    from math import prod
+                    from numpy import prod
+                    print(cs,prod(cs),len(orig_emb))
                     self.assertTrue(len(orig_emb)==prod(cs))
                     self.assertFalse(any(any(key[idx] >= bound for idx,bound in enumerate(cs)) for key in orig_emb))

--- a/tests/test_decomposers.py
+++ b/tests/test_decomposers.py
@@ -674,12 +674,17 @@ class MockDWaveSamplerGeneralization(MockDWaveSampler):
     """Extend the `dwave.system.testing.MockDWaveSampler` to Pegasus topology.
     
     Adding topology and shape keywords to MockDWaveSampler for this purpose.
+    This function is mirrored in test_reference_samplers.py
+
+    MockDWaveSampler() in the latest version of dwave-system support these 
+    options, this function is included to support backward compatibility of the
+    dwave-system package.
     """
-    def __init__(self, broken_nodes=None, qpu_topology=None, qpu_scale=4, **config):
+    def __init__(self, broken_nodes=None, topology_type=None, qpu_scale=4, **config):
         super().__init__(broken_nodes, **config)
         #An Advantage generation processor, only artificially smaller,
         #replaces C4 in default MockDWaveSampler
-        if qpu_topology != 'chimera':
+        if topology_type != 'chimera':
             self.properties['topology'] = {'type': 'pegasus',
                                            'shape': [qpu_scale]}
             qpu_graph = dnx.pegasus_graph(qpu_scale,fabric_only=True)
@@ -737,7 +742,7 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
         Uses a default processor scale of 4, with either 0 or 15
         edge defects.
         """
-        # Expected properties by (qpu_topology, lattice_topology):
+        # Expected properties by (topology_type, lattice_topology):
         # tuple length, chain length, number of embeddings
         shape_dicts = {('pegasus', 'pegasus'): {'tl': 5, 'cl': 1, 'ne': 2},
                        ('pegasus', 'cubic'): {'tl': 3, 'cl': 2, 'ne': 3},
@@ -747,7 +752,7 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
         for qpu_top in ['pegasus', 'chimera']:
             #Native by default:
             shape_dicts[(qpu_top, None)] = shape_dicts[(qpu_top, qpu_top)] 
-            qpu_sampler = MockDWaveSamplerGeneralization(qpu_topology=qpu_top)
+            qpu_sampler = MockDWaveSamplerGeneralization(topology_type=qpu_top)
 
             # pop final 15 edges to exercise edge cover routines.
             # 15 is a worst case upper bound on the number of defects that
@@ -795,7 +800,7 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
                     proposed_source = dnx.chimera_graph(qpu_scale)
                 
                 qpu_sampler = MockDWaveSamplerGeneralization(
-                    qpu_topology=qpu_top,
+                    topology_type=qpu_top,
                     qpu_scale=qpu_scale)
                 for _ in range(15):
                     qpu_sampler.edgelist.pop()
@@ -822,7 +827,7 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
                 # proposed_source: a defect free-lattice at sampler
                 # scale (hence inclusive of all keys).
                 qpu_sampler = MockDWaveSamplerGeneralization(
-                    qpu_topology=qpu_top,
+                    topology_type=qpu_top,
                     qpu_scale=4)
                 cs = constrained_scales[lattice_type]
                 orig_embs = make_origin_embeddings(qpu_sampler=qpu_sampler,

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -21,10 +21,19 @@ from dwave.system.testing import MockDWaveSampler
 import hybrid
 from hybrid.samplers import QPUSubproblemAutoEmbeddingSampler
 from hybrid.reference.kerberos import KerberosSampler
+from hybrid.reference.latticeLNLS import LatticeLNLSSampler
 from hybrid.reference.pa import (
     EnergyWeightedResampler, ProgressBetaAlongSchedule,
     CalculateAnnealingBetaSchedule, PopulationAnnealing
 )
+
+class TestLatticeLNLS(unittest.TestCase):
+
+    def test_basic_operation(self):
+        bqm = dimod.BinaryQuadraticModel({}, {((0,0,0),(0,0,1)): 1, ((1,1,0),(1,1,1)): 1}, 0, dimod.SPIN)
+        sampleset = LatticeLNLSSampler().sample(
+            bqm, problem_dims=(2,2,2), qpu_sampler=MockDWaveSampler(), topology='cubic',
+            qpu_params=dict(chain_strength=2))
 
 
 class TestKerberos(unittest.TestCase):
@@ -173,6 +182,7 @@ class TestReferenceWorkflowsSmoke(unittest.TestCase):
         (hybrid.PopulationAnnealing, dict(num_reads=10, num_iter=10, num_sweeps=10)),
         (hybrid.HybridizedPopulationAnnealing, dict(num_reads=10, num_iter=10, num_sweeps=10)),
         (hybrid.Kerberos, dict(sa_sweeps=10, tabu_timeout=10, qpu_sampler=MockDWaveSampler())),
+        (hybrid.LatticeLNLS, dict(topology='cubic',problem_dims=(18,18,18),qpu_sampler=MockDWaveSampler())),
         (hybrid.SimplifiedQbsolv, dict(max_iter=2)),
     ])
     def test_smoke(self, sampler_cls, sampler_params):

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -75,7 +75,7 @@ class TestLatticeLNLS(unittest.TestCase):
     def test_basic_operation(self):
         bqm = dimod.BinaryQuadraticModel({(i,j,k) : 0 for i in range(2) for j in range(2) for k in range(2)}, {((0,0,0),(0,0,1)): 1, ((1,1,0),(1,1,1)): 1}, 0, dimod.SPIN)
         sampleset = LatticeLNLSSampler().sample(
-            bqm=bqm, problem_dims=(2,2,2), qpu_sampler=MockDWaveSampler(), topology='cubic',max_iter=1,
+            bqm=bqm, problem_dims=(2,2,2), qpu_sampler=MockDWaveSamplerGeneralization(), topology='cubic',max_iter=1,
             qpu_params=dict(chain_strength=2), reject_small_problems=False)
 
 

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -20,7 +20,8 @@ from dwave.system.testing import MockDWaveSampler
 import hybrid
 from hybrid.samplers import QPUSubproblemAutoEmbeddingSampler
 from hybrid.reference.kerberos import KerberosSampler
-from hybrid.reference.latticeLNLS import LatticeLNLSSampler
+from hybrid.reference.lattice_lnls import LatticeLNLSSampler
+from hybrid.reference.lattice_lnls import LatticeLNLS
 from hybrid.decomposers import make_origin_embeddings
 from hybrid.reference.pa import (
     EnergyWeightedResampler, ProgressBetaAlongSchedule,
@@ -71,8 +72,14 @@ class MockDWaveSamplerGeneralization(MockDWaveSampler):
         
 
 class TestLatticeLNLS(unittest.TestCase):
-
-    def test_basic_operation(self):
+    
+    def test_basic_workflow_operation(self):
+        for topology_type in ['pegasus','chimera']:
+            qpu_sampler=MockDWaveSamplerGeneralization(topology_type=topology_type)
+            for lattice_type in ['cubic',topology_type]:
+                LatticeLNLS(topology=lattice_type, qpu_sampler=qpu_sampler)
+                
+    def test_basic_sampler_operation(self):
         bqm = dimod.BinaryQuadraticModel({(i,j,k) : 0 for i in range(2) for j in range(2) for k in range(2)}, {((0,0,0),(0,0,1)): 1, ((1,1,0),(1,1,1)): 1}, 0, dimod.SPIN)
         sampleset = LatticeLNLSSampler().sample(
             bqm=bqm, problem_dims=(2,2,2), qpu_sampler=MockDWaveSamplerGeneralization(), topology='cubic',max_iter=1,

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -30,9 +30,9 @@ from hybrid.reference.pa import (
 class TestLatticeLNLS(unittest.TestCase):
 
     def test_basic_operation(self):
-        bqm = dimod.BinaryQuadraticModel({}, {((0,0,0),(0,0,1)): 1, ((1,1,0),(1,1,1)): 1}, 0, dimod.SPIN)
+        bqm = dimod.BinaryQuadraticModel({(i,j,k) : 0 for i in range(2) for j in range(2) for k in range(2)}, {((0,0,0),(0,0,1)): 1, ((1,1,0),(1,1,1)): 1}, 0, dimod.SPIN)
         sampleset = LatticeLNLSSampler().sample(
-            bqm, problem_dims=(2,2,2), qpu_sampler=MockDWaveSampler(), topology='cubic',
+            bqm=bqm, problem_dims=(2,2,2), qpu_sampler=MockDWaveSampler(), topology='cubic',max_iter=1,
             qpu_params=dict(chain_strength=2))
 
 
@@ -183,6 +183,8 @@ class TestReferenceWorkflowsSmoke(unittest.TestCase):
         (hybrid.HybridizedPopulationAnnealing, dict(num_reads=10, num_iter=10, num_sweeps=10)),
         (hybrid.Kerberos, dict(sa_sweeps=10, tabu_timeout=10, qpu_sampler=MockDWaveSampler())),
         (hybrid.LatticeLNLS, dict(topology='cubic',problem_dims=(18,18,18),qpu_sampler=MockDWaveSampler())),
+        (hybrid.LatticeLNLS, dict(topology='pegasus',problem_dims=(22,22),qpu_sampler=MockDWaveSampler(topology_type='pegasus'))),
+        (hybrid.LatticeLNLS, dict(topology='chimera',problem_dims=(22,22),qpu_sampler=MockDWaveSampler(topology_type='chimera'))),
         (hybrid.SimplifiedQbsolv, dict(max_iter=2)),
     ])
     def test_smoke(self, sampler_cls, sampler_params):

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -112,6 +112,25 @@ class TestQPUSamplers(unittest.TestCase):
         # verify mock sampler received custom kwargs
         self.assertEqual(res.subsamples.first.energy, -1)
 
+    def test_external_embedding_sampler_srt(self):
+        bqm = dimod.BinaryQuadraticModel.from_ising({'a': 1}, {})
+        init = State.from_subproblem(bqm, embedding={'a': [0]})
+
+        sampler = dimod.StructureComposite(
+            SimulatedAnnealingSampler(), nodelist=[0], edgelist=[])
+
+        # Test srt option, introduced as placeholder
+        # functionality for compatibility with latticeLNLS
+        # reference workflows (special case use of extended
+        # J-range)
+        workflow = QPUSubproblemExternalEmbeddingSampler(qpu_sampler=sampler,logical_srt=True)
+
+        # run mock sampling
+        res = workflow.run(init).result()
+
+        # verify mock sampler received custom kwargs
+        self.assertEqual(res.subsamples.first.energy, -1)
+
     @parameterized.expand([['chimera', 2], ['pegasus', 1], ['zephyr', 1]])
     def test_clique_embedder(self, topology_type, expected_chain_length):
         bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': 1, 'bc': 1, 'ca': 1})


### PR DESCRIPTION
Added a lattice solver reference example matching the Kerberos model. 
Support was added to make_origin_embeddings to allow constraints on the size of the embedding (subsolver regions). 
These changes allow for modeing of the workflows in the paper under preparation: Raymond et al. "Hybrid quantum annealing for larger-than-chip lattice-structured problems"