### PR TITLE
Support all structured samplers in SubproblemCliqueEmbedder

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,8 @@ cache:
   - '%AppData%\pip-cache'
 
 build_script:
-  - "%PYTHON%\\python.exe -m pip install -r requirements.txt -r tests\\requirements.txt --cache-dir %AppData%\\pip-cache"
+  - "%PYTHON%\\python.exe -m pip install -r requirements.txt --cache-dir %AppData%\\pip-cache"
+  - "%PYTHON%\\python.exe -m pip install -r tests\\requirements.txt --cache-dir %AppData%\\pip-cache"
 
 before_test:
   - "%PYTHON%\\python.exe -m pip install ."

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,8 @@ jobs:
           command: |
             . env/bin/activate
             pip install -U pip
-            pip install -r requirements.txt -r tests/requirements.txt
+            pip install -r requirements.txt
+            pip install -r tests/requirements.txt
             pip install wheel twine
 
       - save_cache: &save-cache-env

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dimod==0.10.13
 numpy>=1.19.1
 minorminer==0.2.7
-dwave-system==1.11.0
+dwave-system==1.13.0
 dwave-neal==0.5.9
 dwave-tabu==0.4.3
 dwave-greedy==0.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dimod==0.10.13
 numpy>=1.19.1
 minorminer==0.2.7
-dwave-system==1.13.0
+dwave-system==1.11.0
 dwave-neal==0.5.9
 dwave-tabu==0.4.3
 dwave-greedy==0.2.3

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,3 @@
 coverage
 codecov
 parameterized
-dwave-system>=1.13.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 coverage
 codecov
 parameterized
+dwave-system>=1.13.0

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -112,7 +112,7 @@ class TestQPUSamplers(unittest.TestCase):
         # verify mock sampler received custom kwargs
         self.assertEqual(res.subsamples.first.energy, -1)
 
-    @parameterized.expand([['chimera', 2], ['pegasus', 1]])
+    @parameterized.expand([['chimera', 2], ['pegasus', 1], ['zephyr', 1]])
     def test_clique_embedder(self, topology_type, expected_chain_length):
         bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': 1, 'bc': 1, 'ca': 1})
         init = State.from_subproblem(bqm)

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -17,16 +17,19 @@ import time
 from operator import attrgetter
 
 import numpy as np
-from parameterized import parameterized_class
+from parameterized import parameterized, parameterized_class
 
 import dimod
 from neal import SimulatedAnnealingSampler
+from dwave.system import DWaveSampler
 from dwave.system.testing import MockDWaveSampler
 
 from hybrid.samplers import *
 from hybrid.core import State
 from hybrid.testing import mock
 from hybrid.utils import random_sample
+
+MockDWaveSampler.to_networkx_graph = DWaveSampler.to_networkx_graph
 
 
 class MockDWaveReverseAnnealingSampler(MockDWaveSampler):
@@ -109,12 +112,12 @@ class TestQPUSamplers(unittest.TestCase):
         # verify mock sampler received custom kwargs
         self.assertEqual(res.subsamples.first.energy, -1)
 
-    def test_clique_embedder(self):
+    @parameterized.expand([['chimera', 2], ['pegasus', 1]])
+    def test_clique_embedder(self, topology_type, expected_chain_length):
         bqm = dimod.BinaryQuadraticModel.from_ising({}, {'ab': 1, 'bc': 1, 'ca': 1})
         init = State.from_subproblem(bqm)
 
-        sampler = MockDWaveSampler()
-
+        sampler = MockDWaveSampler(topology_type=topology_type)
         workflow = SubproblemCliqueEmbedder(sampler=sampler)
 
         # run embedding
@@ -123,8 +126,10 @@ class TestQPUSamplers(unittest.TestCase):
         # verify mock sampler received custom kwargs
         self.assertIn('embedding', res)
         self.assertEqual(len(res.embedding.keys()), 3)
-        # embedding a triangle onto a chimera produces 3 x 2-qubit chains
-        self.assertTrue(all(len(e) == 2 for e in res.embedding.values()))
+
+        # embedding a triangle onto a chimera produces 3 x 2-qubit chains;
+        # if embedding onto pegasus the chains have length 1.
+        self.assertTrue(all(len(e) == expected_chain_length for e in res.embedding.values()))
 
     def test_reverse_annealing_sampler(self):
         sampler = MockDWaveReverseAnnealingSampler()


### PR DESCRIPTION
Fixes #264

To be clear, all structured samplers with topologies _that are supported by `minorminer.busclique`_ are supported in `SubproblemCliqueEmbedder` with this change.

Both chimera- and pegasus-structured (mock) samplers are explicitly tested in composition with `SubproblemCliqueEmbedder` in unit tests with this change.  Support for zephyr-structured samplers has been confirmed with manual testing.  ~~Not adding a unit test for Zephyr at this time - we will have to change `requirements.txt` to depend on a newer [1] `dwave-system` for that.~~

~~[1] Not sure what is the exact minimum version that we would need for this, but it is no less than `1.13.0` as we need dwavesystems/dwave-system@79fcf55cc39d33c5e2a3c45d301da397fa677b2b~~

**Edit:** Added a unit test for Zephyr also.