### PR TITLE
Add lattice ref solver to docs

### DIFF
--- a/docs/reference/reference.rst
+++ b/docs/reference/reference.rst
@@ -35,5 +35,5 @@ qbsolv
 latticeLNLS
 ===========
 
-.. automodule:: hybrid.reference.latticeLNLS
+.. automodule:: hybrid.reference.lattice_lnls
    :members:


### PR DESCRIPTION
Closes https://github.com/dwavesystems/dwave-hybrid/issues/280 noted by @jackraymond 