### PR TITLE
Fix async multiprocess queue logging test

### DIFF
--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1079,7 +1079,7 @@ class TestLog(unittest.TestCase):
         res = []
         while True:
             try:
-                res.append(memo.get_nowait())
+                res.append(memo.get(timeout=1))
             except queue.Empty:
                 break
 


### PR DESCRIPTION
Reason: in mp, put is async, it takes nonzero time.

Fix #279.