### PR TITLE
Drop Python 3.7 and refresh CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
 
   test-docs:
     docker:
-      - image: cimg/python:3.7
+      - image: cimg/python:3.9
 
     steps:
       - checkout
@@ -255,7 +255,7 @@ workflows:
           name: test-linux-<< matrix.python-version >> | << matrix.pip-constraints >>
           matrix:
             parameters:
-              python-version: &python-versions ["3.7.9", "3.8.6", "3.9.0", "3.10.0", "3.11.0"]
+              python-version: &python-versions ["3.8.6", "3.9.0", "3.10.0", "3.11.0"]
               pip-constraints:
                 - "dimod==0.10.13"
                 - "dimod~=0.10.0 dwave-preprocessing~=0.3.0 dwave-system~=1.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,7 @@ workflows:
           name: test-linux-<< matrix.python-version >> | << matrix.pip-constraints >>
           matrix:
             parameters:
-              python-version: &python-versions ["3.8.6", "3.9.0", "3.10.0", "3.11.0"]
+              python-version: &python-versions ["3.8", "3.9", "3.10", "3.11"]
               pip-constraints:
                 - "dimod==0.10.13"
                 - "dimod~=0.10.0 dwave-preprocessing~=0.3.0 dwave-system~=1.0"
@@ -263,11 +263,11 @@ workflows:
                 - "dimod~=0.12.0 dwave-preprocessing~=0.5.0 dwave-system~=1.0"
             exclude:
               # dimod < 0.12 not supported on py311+
-              - python-version: "3.11.0"
+              - python-version: "3.11"
                 pip-constraints: "dimod==0.10.13"
-              - python-version: "3.11.0"
+              - python-version: "3.11"
                 pip-constraints: "dimod~=0.10.0 dwave-preprocessing~=0.3.0 dwave-system~=1.0"
-              - python-version: "3.11.0"
+              - python-version: "3.11"
                 pip-constraints: "dimod~=0.11.0 dwave-preprocessing~=0.4.0 dwave-system~=1.0"
 
       - test-macos:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,20 +81,9 @@ jobs:
     steps:
       - checkout
 
-      # install `python-version` and cache it
-      - when:
-          condition:
-            matches:
-              pattern: "^3\\.[123][123456789].*$"
-              value: << parameters.python-version >>
-          steps:
-            - run:
-                name: Update brew to get latest pyenv
-                command: brew update
-
       - run: &brew-install-pyenv
           name: Install pyenv
-          command: HOMEBREW_NO_AUTO_UPDATE=1 brew install pyenv
+          command: brew install pyenv
 
       - restore_cache: &restore-cache-pyenv
           keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ parameters:
 
 orbs:
   win: circleci/windows@5.0
+  codecov: codecov/codecov@3
 
 environment:
   PIP_PROGRESS_BAR: 'off'
@@ -60,13 +61,13 @@ jobs:
 
       - run: &run-python-tests
           name: Run Python tests
-          command: env/bin/coverage run -m unittest discover
-
-      - run: &upload-python-code-coverage
-          name: Upload code coverage
           command: |
             . env/bin/activate
-            codecov     # calls `coverage xml`, so we must activate venv
+            coverage run -m unittest discover
+            coverage xml
+
+      - codecov/upload: &upload-python-code-coverage
+          file: coverage.xml
 
   test-macos:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 parameters:
   cache-generation:
     type: integer
-    default: 1
+    default: 2
 
 orbs:
-  win: circleci/windows@2.2
+  win: circleci/windows@5.0
 
 environment:
   PIP_PROGRESS_BAR: 'off'
@@ -31,6 +31,7 @@ jobs:
       - run: &create-virtualenv
           name: Create virtual environment
           command: |
+            python -V
             python -m venv env
 
       - run: &install-requirements
@@ -132,20 +133,20 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          keys:
-            - v<< pipeline.parameters.cache-generation >>-nuget-python-<< parameters.python-version >>-{{ .Environment.CIRCLE_JOB }}
-
       - run:
           name: Install python and create virtualenv
+          shell: bash -eo pipefail
           command: |
-            nuget install python -Version << parameters.python-version >>
-            python.<< parameters.python-version >>\tools\python -m venv env
-
-      - save_cache:
-          key: v<< pipeline.parameters.cache-generation >>-nuget-python-<< parameters.python-version >>-{{ .Environment.CIRCLE_JOB }}
-          paths:
-            - python.<< parameters.python-version >>
+            # resolve python MAJOR.MINOR version to latest MAJOR.MINOR.PATCH version available on NuGet
+            full_version=$(
+              curl -s 'https://azuresearch-usnc.nuget.org/query?q=python' \
+              | jq -r '.data[] | select(.id == "python") .versions[] | .version' \
+              | awk -F. -v ver='<< parameters.python-version >>' \
+                  'index($0, ver".") == 1 && $3 > m { m = $3; v = $0 } END { print v }'
+            )
+            nuget install python -Version "$full_version" -ExcludeVersion
+            python/tools/python -V
+            python/tools/python -m venv env
 
       - run:
           name: Install requirements

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ jobs:
         type: string
       xcode:
         type: string
-        default: "13.2.0"
+        default: "14.2.0"
 
     macos:
       xcode: << parameters.xcode >>

--- a/setup.py
+++ b/setup.py
@@ -25,14 +25,13 @@ extras_require = {
     'test': ['coverage'],
 }
 
-python_requires = ">=3.7"
+python_requires = ">=3.8"
 
 classifiers = [
     'License :: OSI Approved :: Apache Software License',
     'Operating System :: OS Independent',
     'Development Status :: 3 - Alpha',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ install_requires = ['numpy>=1.19.1', 'networkx', 'click>5', 'plucky>=0.4.3',
                     # as it's already constrained by dimod (if required).
                     'dwave-preprocessing',
                     'minorminer>=0.1.7', 'dwave-networkx>=0.8.8', 'dwave-system>=1.13.0',
+                    'dwave-cloud-client>=0.10.6',   # avoid pydantic 2.0 backward compat break
                     'dwave-neal>=0.5.4', 'dwave-tabu>=0.2.0', 'dwave-greedy>=0.1.0']
 
 # Package extras requirements


### PR DESCRIPTION
- drop py37
- upgrade xcode to fix CircleCI macos builds on the medium resource class
- always run on the latest patch version of python (includes a workaround on windows)