### PR TITLE
Add support for Kings graph in large neighborhood search

### DIFF
--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -984,11 +984,6 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
                     arXiv:2003.00133 are created for a ``qpu_sampler`` of
                     topology type either 'pegasus' or 'chimera'.
                 
-                * "square-next-neighbor"
-                    Embedding sufficient for a square lattice plus next-neighbor
-                    interactions for a ``qpu_sampler`` of type 'zephyr'. Chain
-                    length 2.
-
                 * "kings"
                     Embedding compatible with arXiv:2003.00133.pdf Table 1,
                     are created for a ``qpu_sampler`` of topology type either

--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -35,6 +35,8 @@ from hybrid.utils import (
     bqm_induced_by, flip_energy_gains, select_random_subgraph,
     chimera_tiles)
 
+from typing import Tuple
+
 __all__ = [
     'IdentityDecomposer', 'ComponentDecomposer', 'EnergyImpactDecomposer', 
     'RandomSubproblemDecomposer', 'TilingChimeraDecomposer', 
@@ -729,7 +731,7 @@ def _all_minimal_covers(edgelist):
 
     if len(edgelist) > 16:
         raise ValueError(
-            'len(edgelist) > 16. Exponential scaling of this method means it '
+            f'len(edgelist) = {len(edgelist)} > 16. Exponential scaling of this method means it '
             'should only be used for small graphs. The use case for this function '
             'is in finding coverings over unyielded lattice subgraphs, which in '
             'the current online generation of processors are sufficiently small '
@@ -805,6 +807,119 @@ def _yield_limited_origin_embedding(origin_embedding, proposed_source, target):
     origin_embedding = {k: v for k, v in origin_embedding.items() if k in max_cc}
     return origin_embedding
 
+def _kings_node_to_pegasus_chain(row: int, col: int) -> Tuple[
+    Tuple[int, int, int, int], Tuple[int, int, int, int]]: 
+    """"Embed a node into a chain for a grid-with-diagonal (Kings) lattice.
+
+    Args:
+        row: Row in the lattice.
+
+        col: Column in the lattice.
+
+    Returns:
+        Two-tuple of the two nodes, in Pegasus coordinates, that constitute a
+            chain representing the given node. 
+
+    References:
+    
+    * https://arxiv.org/pdf/2003.00133.pdf Table 1
+    """
+    row_par = row%3
+    col_par = col%3
+    x = col//3
+    y = row//3
+    if row_par == 0:
+        if col_par == 0:
+            return (0, x, 2, y), (1 ,y, 7, x)
+        elif col_par == 1:
+            return (0, x+1, 0, y), (1, y, 2, x)
+        else:
+            return (0, x+1, 3, y), (1, y, 8, x)
+    elif row_par == 1:
+        if col_par == 0:
+            return (0, x, 8, y), (1, y, 6, x)
+        elif col_par == 1:
+            return (0, x, 11, y), (1, y+1, 0, x)
+        else:
+            return (0, x, 10, y), (1, y, 11, x)
+    else:
+        if col_par == 0:
+            return (0, x, 7, y), (1, y+1, 4, x)
+        elif col_par == 1:
+            return (0, x, 6, y), (1, y+1, 3, x)
+        elif col_par == 2:
+            return (0, x+1, 4, y), (1, y, 10, x)
+
+def _zephyr_to_crosslike(coord, t=4):
+    """Map Zephyr[m,t] coordinates to Chimera[2m,2m,t]-style coordinates 
+    
+    """
+    u, w, k, j, z = coord
+    row = u*w + (1-u)*(2*z + j)
+    col = (1-u)*w + u*(2*z + j)
+    half_cell = t//2  # note, t is even by Zephyr graph definition
+    return row + u*(k//half_cell) + (1-u) - 1, col + (1-u)*(k//half_cell) + u - 1, u, (k+half_cell)%t
+
+def _crosslike_to_zephyr(coord, t=4):
+    """Map Chimera-like[2m,2m,t] coordinates to Standard Zephyr[m,t] coordinates
+    e.g. (0,0,0,0) -> (0,0,2,0,0)
+         (0,0,0,4) -> (0,1,1,0,0)
+         (0,0,1,0) -> (1,0,2,0,0)
+         (0,0,1,4) -> (1,1,1,0,0)
+    """
+    r, c, u, k = coord
+    half_cell = t//2 
+    k = (k+half_cell)%t
+    
+    row = r - u*(k//half_cell) - (1-u) + 1
+    col = c - (1-u)*(k//half_cell) - u + 1
+    w = u*row + (1-u)*col  # w labels u-dependent displacement from the origin.
+    # row + col = w + 2*z + j  # displacement in other orientation is 2*z+j
+    j = (row + col - w) % 2
+    z = (row + col - w - j) // 2
+    return u, w, k, j, z
+
+def _squareNNN_node_to_zephyr_chain(row: int, col: int) -> Tuple[
+    Tuple[int, int, int, int], Tuple[int, int, int, int]]: 
+    """"Embed a node into a chain for a grid plus next-neighbors lattice.
+    
+    Args:
+        row: Row in the lattice.
+
+        col: Column in the lattice.
+
+    Returns:
+        Two-tuple of the two nodes, in Zephyr coordinates, that constitute a
+            chain representing the given node. 
+
+    Zephyr[m,t] can be tiled with 4 Chimera[m,t]-like cells (minus boundary 
+    effect), _zephyr_to_crosslike(coord) creates a Chimera vector scheme
+    for this tiling.
+    Grid (x,y) to chain (u,k) on each cell in chimera-like coordinate scheme, 
+    we can embed one square per cell. So we can embed a 2m x 2m next-nearest 
+    neighbor 
+      Even parity cell relative coordinates     Odd parity
+              (0,0)    (1,0)                  (0,0)    (0,1)
+              (0,1)    (1,1)                  (1,0)    (1,1)
+     Standard chimera-like presentation of (u,k) (orientation, tile parameter)
+              (1, 0)
+              (1, 1)
+     (0,0) (0,1)  (0,2) (0,3)
+              (1, 2)
+              (1, 3)
+    
+    """
+    local_embedding = {(0,0): ((0,0,0,0), (0,0,1,1)),
+                       (1,0): ((0,0,0,1), (0,0,1,3)),
+                       (0,1): ((0,0,1,0), (0,0,0,2)),
+                       (1,1): ((0,0,1,2), (0,0,0,3))}
+    if row == col:
+        local_key = (row % 2, col % 2)
+    else:
+        parity = (row//2 + col//2) % 2
+        local_key = ((row+parity) % 2, (col + parity) % 2)
+    return tuple([_crosslike_to_zephyr((coord[0]+2*row, coord[1]+2*col, coord[2], coord[3])) for coord in local_embedding[local_key]])
+
 
 def _make_cubic_lattice(dimensions):
     """Returns an open boundary cubic lattice graph as function of lattice
@@ -827,6 +942,25 @@ def _make_cubic_lattice(dimensions):
                                         for z in range(dimensions[2]-1)
                                         ])
     return cubic_lattice_graph
+
+def _make_kings_lattice(dimensions):
+    """Returns an open boundary cubic lattice graph as function of lattice
+    dimensions. Helper function for ``make_origin_embeddings``.
+    """
+    kings_lattice = nx.Graph()
+    kings_lattice.add_edges_from([((x, y), (x+1, y))
+                                  for x in range(dimensions[0]-1)
+                                  for y in range(dimensions[1])])
+    kings_lattice.add_edges_from([((x, y), (x, y+1))
+                                  for x in range(dimensions[0])
+                                  for y in range(dimensions[1]-1)])
+    kings_lattice.add_edges_from([((x, y+1), (x, y+1))
+                                  for x in range(dimensions[0]-1)
+                                  for y in range(dimensions[1]-1)])
+    kings_lattice.add_edges_from([((x+1, y), (x, y+1))
+                                  for x in range(dimensions[0]-1)
+                                  for y in range(dimensions[1]-1)])
+    return kings_lattice
 
 
 def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
@@ -852,7 +986,17 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
                     Embeddings compatible with the schemes arXiv:2009.12479 and
                     arXiv:2003.00133 are created for a ``qpu_sampler`` of
                     topology type either 'pegasus' or 'chimera'.
+                
+                * "square-next-neighbor"
+                    Embedding sufficient for a square lattice plus next-neighbor
+                    interactions for a ``qpu_sampler`` of type 'zephyr'. Chain
+                    length 2.
 
+                * "kings"
+                    Embedding compatible with arXiv:2003.00133.pdf Table 1,
+                    are created for a ``qpu_sampler`` of topology type either
+                    'pegasus', or 'zephyr'. Chain length 2. 
+    
                 * "pegasus"
                     Embeddings are chain length one (minimal and native).
                     If ``qpu_sampler`` topology type is 'pegasus', maximum
@@ -1033,16 +1177,48 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
                                      and target.has_edge(vec_to_lin((2*x+1, 2*y+1, 0, z)),
                                                          vec_to_lin((2*x,2*y+1,0,z)))
                                      })
+            
         else:
             raise ValueError(f'Unsupported qpu_sampler topology {qpu_type} '
                              'for cubic lattice solver')
 
         proposed_source = _make_cubic_lattice(dimensions)
+    elif lattice_type == 'kings':
+        if qpu_type == 'pegasus':
+            vec_to_lin = dnx.pegasus_coordinates(qpu_shape[0]).pegasus_to_linear
+            L = 3*(qpu_shape[0] - 1)
+            dimensions = (L, L)
+            to_chain = _kings_node_to_pegasus_chain
+        elif qpu_type == 'zephyr':
+            if qpu_shape[1] != 4:
+                raise ValueError('Method is suitable for Zephyr[m,t=4] only')
+            vec_to_lin = dnx.zephyr_coordinates(qpu_shape[0], qpu_shape[1]).zephyr_to_linear
+            L = 4 * qpu_shape[0]
+            dimensions = (L, L)
+            to_chain = _squareNNN_node_to_zephyr_chain
+        else:
+            raise ValueError(f'Unsupported qpu_sampler topology {qpu_type} '
+                             'for kings lattice solver')
+        origin_embedding = {(x, y): to_chain(x, y)
+                            for x in range(L) for y in range(L)
+        }  # Defect free, coordinates
+        if qpu_type == 'zephyr':
+            print(qpu_type, origin_embedding, qpu_sampler.properties['topology'])
+        origin_embedding = {k: tuple(vec_to_lin(q) for q in v)
+                            for k, v in origin_embedding.items()
+                            if target.has_edge(vec_to_lin(v[0]),vec_to_lin(v[1]))
+        }  # Omit broken chains, map to linear
+        if qpu_type == 'zephyr':
+            print(qpu_type, origin_embedding, qpu_sampler.properties['topology'])
+            raise ValueError('Monkey')
+        proposed_source = _make_kings_lattice(dimensions)
     else:
-        raise ValueError('Unsupported combination of lattice_type '
-                         'and qpu_sampler topology')
+        raise ValueError(f'Unsupported combination of {lattice_type}'
+                         f'and qpu_sampler topology ({topology})')
 
     if not allow_unyielded_edges:
+        if qpu_type == 'zephyr' and  lattice_type == 'kings':
+            print(origin_embedding, target)
         origin_embedding = _yield_limited_origin_embedding(origin_embedding,
                                                            proposed_source,
                                                            target)
@@ -1068,6 +1244,11 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
         origin_embeddings.append({(key[1], key[2], key[0]): value
                                   for key, value in origin_embedding.items()})
         problem_dim_spec = 3
+    elif lattice_type == 'kings':
+        # A reflection is sufficient for demonstration purposes
+        origin_embeddings.append({(key[1], key[0]): value
+                                  for key, value in origin_embedding.items()})
+        problem_dim_spec = 2
     elif lattice_type == 'pegasus':
         # A horizontal to vertical flip is sufficient for demonstration purposes.
         # Flip north-east to south-west axis (see draw_pegasus):
@@ -1083,6 +1264,7 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
         problem_dim_spec = 4
     else:
         raise ValueError('Unsupported lattice_type')
+
     if problem_dims is not None:
         if len(problem_dims) != problem_dim_spec:
             raise ValueError('len(problem_dims) is incompatible with'

--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -940,23 +940,23 @@ def _make_cubic_lattice(dimensions):
                                         ])
     return cubic_lattice_graph
 
-def _make_kings_lattice(dimensions):
+def _make_kings_lattice(dimensions, is_open=(True,True)):
     """Returns an open boundary cubic lattice graph as function of lattice
     dimensions. Helper function for ``make_origin_embeddings``.
     """
     kings_lattice = nx.Graph()
-    kings_lattice.add_edges_from([((x, y), (x+1, y))
-                                  for x in range(dimensions[0]-1)
+    kings_lattice.add_edges_from([((x, y), ((x+1)%dimensions[0], y))
+                                  for x in range(dimensions[0]- is_open[0])
                                   for y in range(dimensions[1])])
-    kings_lattice.add_edges_from([((x, y), (x, y+1))
+    kings_lattice.add_edges_from([((x, y), (x, (y+1)%dimensions[1]))
                                   for x in range(dimensions[0])
-                                  for y in range(dimensions[1]-1)])
-    kings_lattice.add_edges_from([((x, y+1), (x, y+1))
-                                  for x in range(dimensions[0]-1)
-                                  for y in range(dimensions[1]-1)])
-    kings_lattice.add_edges_from([((x+1, y), (x, y+1))
-                                  for x in range(dimensions[0]-1)
-                                  for y in range(dimensions[1]-1)])
+                                  for y in range(dimensions[1]- is_open[1])])
+    kings_lattice.add_edges_from([((x, y), ((x+1)%dimensions[0], (y+1)%dimensions[1]))
+                                  for x in range(dimensions[0]- is_open[0])
+                                  for y in range(dimensions[1]- is_open[1])])
+    kings_lattice.add_edges_from([(((x+1)%dimensions[0], y), (x, (y+1)%dimensions[1]))
+                                  for x in range(dimensions[0]- is_open[0])
+                                  for y in range(dimensions[1]- is_open[1])])
     return kings_lattice
 
 

--- a/hybrid/reference/lattice_lnls.py
+++ b/hybrid/reference/lattice_lnls.py
@@ -54,6 +54,8 @@ def LatticeLNLS(topology,
 
                 * 'cubic' (``qpu_sampler`` must be pegasus of chimera-structured)
 
+                * 'kings' (``qpu_sampler`` must be pegasus of zephyr-structured)
+
                 * 'chimera' (``qpu_sampler`` must be chimera-structured)
 
         qpu_sampler (:class:`dimod.Sampler`, optional, default=DWaveSampler()):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -280,14 +280,8 @@ class TestNumpyJSONEncoder(unittest.TestCase):
 
     @parameterized.expand([
         (numpy.array([1, 2, 3], dtype=int), [1, 2, 3]),
-<<<<<<< HEAD
         (numpy.array([[1], [2], [3]], dtype=float), [[1.0], [2.0], [3.0]]),
         (numpy.zeros((2, 2), dtype=bool), [[False, False], [False, False]]),
-
-=======
-        (numpy.array([[1], [2], [3]], dtype=numpy.double), [[1.0], [2.0], [3.0]]),
-        (numpy.zeros((2, 2), dtype=numpy.bool_), [[False, False], [False, False]]),
->>>>>>> 5fcb2c868da9d699f24fab7484b5da9d23e62b5d
         (numpy.array([('Rex', 9, 81.0), ('Fido', 3, 27.0)],
                      dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')]),
          [['Rex', 9, 81.0], ['Fido', 3, 27.0]]),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -282,6 +282,7 @@ class TestNumpyJSONEncoder(unittest.TestCase):
         (numpy.array([1, 2, 3], dtype=int), [1, 2, 3]),
         (numpy.array([[1], [2], [3]], dtype=float), [[1.0], [2.0], [3.0]]),
         (numpy.zeros((2, 2), dtype=bool), [[False, False], [False, False]]),
+
         (numpy.array([('Rex', 9, 81.0), ('Fido', 3, 27.0)],
                      dtype=[('name', 'U10'), ('age', 'i4'), ('weight', 'f4')]),
          [['Rex', 9, 81.0], ['Fido', 3, 27.0]]),


### PR DESCRIPTION
Add support for Kings graph solving using chain length two Zephyr and Pegasus embeddings.
The Kings graph is relevant to recent demos in cooperative multipoint.
Subroutines can be reused for other 2d lattices.