### PR TITLE
Enable optional metadata tracking in LNLS

### DIFF
--- a/hybrid/reference/lattice_lnls.py
+++ b/hybrid/reference/lattice_lnls.py
@@ -85,8 +85,8 @@ def LatticeLNLS(topology,
                    each iteration.
 
         track_iteration_data (bool, optional, default=False):
-            Flag to indicate whether to track samples, subproblems, and subsamples (samples for the
-            subproblem).
+            Flag indicating whether to track samples, subproblems, and subsamples (samples for the
+            subproblem) in the `hybrid.State` of the workflow.
 
         max_iter (int, optional, default=128):
             Number of iterations in the hybrid algorithm.
@@ -250,9 +250,9 @@ class LatticeLNLSSampler(dimod.Sampler):
                 the hybrid algorithm.
 
             track_iteration_data (bool, optional, default=False):
-                Flag to indicate whether to track samples, subproblems, and subsamples (samples for
-                the subproblem).
-
+                Flag indicating whether to track samples, subproblems, and subsamples (samples for
+                the subproblem) in the returned sample set's `info` field. One list of tracked data
+                is stored per read (as in `num_reads`).
 
             problem_dims (tuple of ints):
                 Lattice dimensions (e.g. cubic case (18,18,18)).

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -85,7 +85,7 @@ class TestLatticeLNLS(unittest.TestCase):
             bqm=bqm, problem_dims=(2,2,2), qpu_sampler=MockDWaveSampler(), topology='cubic',max_iter=1,
             qpu_params=dict(chain_strength=2), reject_small_problems=False)
 
-    def test_track_iteration_data(self):
+    def test_track_qpu_branch(self):
         h = {(i,j,k) : 0 for i in range(2) for j in range(2) for k in range(2)}
         J = {((0,0,0),(0,0,1)): 1, ((1,1,0),(1,1,1)): 1}
         bqm = dimod.BinaryQuadraticModel(h, J, 0, dimod.SPIN)

--- a/tests/test_reference_samplers.py
+++ b/tests/test_reference_samplers.py
@@ -96,7 +96,7 @@ class TestLatticeLNLS(unittest.TestCase):
             bqm=bqm, problem_dims=(2,2,2), num_reads=num_reads,
             qpu_sampler=MockDWaveSampler(), topology='cubic',max_iter=max_iter,
             qpu_params=dict(chain_strength=2), reject_small_problems=False,
-            track_iteration_data=False
+            track_qpu_branch=False
             )
 
         self.assertEquals(False, 'tracked_samples' in sampleset.info)
@@ -107,7 +107,7 @@ class TestLatticeLNLS(unittest.TestCase):
             bqm=bqm, problem_dims=(2,2,2), num_reads=num_reads,
             qpu_sampler=MockDWaveSampler(), topology='cubic',max_iter=max_iter,
             qpu_params=dict(chain_strength=2), reject_small_problems=False,
-            track_iteration_data=True
+            track_qpu_branch=True
             )
 
         self.assertEquals(num_reads, len(sampleset.info['tracked_samples']))


### PR DESCRIPTION
Add feature to track subsamples (QPU results), subproblems (BQMs sent to QPU), and samples (burndown)