### PR TITLE
Add support for cubic lattice embeddings on zephyr to make_origin_embedding

### DIFF
--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -1170,11 +1170,11 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
             def zephyr_chain(x, y, z):
                 return (vec_to_lin((0, 2*y + (z//t)%2, z%t, z//(2*t), x)),
                         vec_to_lin((1, 2*x + (z//t)%2, z%t, z//(2*t), y)))
-            origin_embedding = {(x, y, z): zephyr_chain(x,y,z)
+            origin_embedding = {(x, y, z): c
                                 for x in range(dimensions[0])
                                 for y in range(dimensions[1])
                                 for z in range(dimensions[2])
-                                if target.has_edge(*zephyr_chain(x, y, z))}
+                                if target.has_edge(*(c := zephyr_chain(x, y, z)))}
         elif qpu_type == 'pegasus':
             vec_to_lin = dnx.pegasus_coordinates(qpu_shape[0]).pegasus_to_linear
             L = qpu_shape[0] - 1

--- a/hybrid/decomposers.py
+++ b/hybrid/decomposers.py
@@ -1145,15 +1145,13 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
             proposed_source = dnx.pegasus_graph(qpu_shape[0], nice_coordinates=True)
             proposed_source = nx.relabel_nodes(
                 proposed_source,
-                {q: dnx.pegasus_coordinates(qpu_shape[0]).nice_to_linear(q)
+                {q: dnx.pegasus_coordinates(*qpu_shape).nice_to_linear(q)
                  for q in proposed_source.nodes()})
-            lin_to_vec = dnx.pegasus_coordinates(qpu_shape[0]).linear_to_nice
+            lin_to_vec = dnx.pegasus_coordinates(*qpu_shape).linear_to_nice
 
         elif lattice_type == 'chimera':
-            proposed_source = dnx.chimera_graph(qpu_shape[0],
-                                                qpu_shape[1],
-                                                qpu_shape[2])
-            lin_to_vec = dnx.chimera_coordinates(qpu_shape[0]).linear_to_chimera
+            proposed_source = dnx.chimera_graph(*qpu_shape)
+            lin_to_vec = dnx.chimera_coordinates(*qpu_shape).linear_to_chimera
         else:
             raise ValueError(
                 f'Unsupported native processor topology {qpu_type}. '
@@ -1162,7 +1160,7 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
 
     elif lattice_type == 'cubic':
         if qpu_type == 'zephyr':
-            vec_to_lin = dnx.zephyr_coordinates(qpu_shape[0], qpu_shape[1]).zephyr_to_linear
+            vec_to_lin = dnx.zephyr_coordinates(*qpu_shape).zephyr_to_linear
             L = max(1, qpu_shape[0]-1)
             _, t = qpu_shape
             dimensions = [L, L, 4*t]
@@ -1170,36 +1168,28 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
             def zephyr_chain(x, y, z):
                 return (vec_to_lin((0, 2*y + (z//t)%2, z%t, z//(2*t), x)),
                         vec_to_lin((1, 2*x + (z//t)%2, z%t, z//(2*t), y)))
-            origin_embedding = {(x, y, z): c
-                                for x in range(dimensions[0])
-                                for y in range(dimensions[1])
-                                for z in range(dimensions[2])
-                                if target.has_edge(*(c := zephyr_chain(x, y, z)))}
+            origin_embedding = {coord: c
+                                for coord in product(*map(range, dimensions))
+                                if target.has_edge(*(c := zephyr_chain(*coord)))}
         elif qpu_type == 'pegasus':
-            vec_to_lin = dnx.pegasus_coordinates(qpu_shape[0]).pegasus_to_linear
+            vec_to_lin = dnx.pegasus_coordinates(*qpu_shape).pegasus_to_linear
             L = qpu_shape[0] - 1
             dimensions = [L, L, 12]
             # See arXiv:2003.00133
             def pegasus_chain1(x, y, z):
                 return (vec_to_lin((0, x, z+4, y)),
                         vec_to_lin((1, y+1, 7-z, x)))
-            origin_embedding = {(x, y, z): pegasus_chain1(x, y, z)
-                                for x in range(L)
-                                for y in range(L)
-                                for z in range(8)
-                                if target.has_edge(*pegasus_chain1(x, y, z))}
+            origin_embedding = {coord: c
+                                for coord in product(*map(range, (L, L, 8)))
+                                if target.has_edge(*(c := pegasus_chain1(*coord)))}
             def pegasus_chain2(x, y, z):
                 return (vec_to_lin((0, x+1, z-8, y)),
                          vec_to_lin((1, y, 19-z, x)))
-            origin_embedding.update({(x, y, z): pegasus_chain2(x, y, z)
-                                     for x in range(L)
-                                     for y in range(L)
-                                     for z in range(8, 12)
-                                     if target.has_edge(*pegasus_chain2(x, y, z))})
+            origin_embedding.update({(x, y, z+8): c
+                                     for x, y, z in product(*map(range, (L, L, 4)))
+                                     if target.has_edge(*(c := pegasus_chain2(x, y, z+8)))})
         elif qpu_type == 'chimera':
-            vec_to_lin = dnx.chimera_coordinates(qpu_shape[0],
-                                                 qpu_shape[1],
-                                                 qpu_shape[2]).chimera_to_linear
+            vec_to_lin = dnx.chimera_coordinates(*qpu_shape).chimera_to_linear
             L = qpu_shape[0] // 2 
             dimensions = [L, L, 8]
             # See arxiv:2009.12479, one choice amongst many
@@ -1208,7 +1198,7 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
                                                                  (2*x, 2*y, 0, z),
                                                                  (2*x, 2*y, 1, z),
                                                                  (2*x, 2*y+1, 1, z)]]
-                                for x in range(L) for y in range(L) for z in range(4)
+                                for x, y, z in product(*map(range, (L, L, 4)))
                                 if target.has_edge(vec_to_lin((2*x+1, 2*y, 0, z)),
                                                    vec_to_lin((2*x, 2*y, 0, z)))
                                 and target.has_edge(vec_to_lin((2*x, 2*y, 0, z)),
@@ -1221,9 +1211,7 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
                                                                       (2*x+1, 2*y+1, 1, z),
                                                                       (2*x+1, 2*y+1, 0, z),
                                                                       (2*x, 2*y+1, 0, z)]]
-                                     for x in range(L)
-                                     for y in range(L)
-                                     for z in range(4)
+                                     for x, y, z in product(*map(range, (L, L, 4)))
                                      if target.has_edge(vec_to_lin((2*x+1, 2*y, 1, z)),
                                                         vec_to_lin((2*x+1, 2*y+1, 1, z)))
                                      and target.has_edge(vec_to_lin((2*x+1, 2*y+1, 1, z)),
@@ -1239,14 +1227,14 @@ def make_origin_embeddings(qpu_sampler=None, lattice_type=None,
         proposed_source = _make_cubic_lattice(dimensions)
     elif lattice_type == 'kings':
         if qpu_type == 'pegasus':
-            vec_to_lin = dnx.pegasus_coordinates(qpu_shape[0]).pegasus_to_linear
+            vec_to_lin = dnx.pegasus_coordinates(*qpu_shape).pegasus_to_linear
             L = 3*(qpu_shape[0] - 1)
             dimensions = (L, L)
             to_chain = _kings_node_to_pegasus_chain
         elif qpu_type == 'zephyr':
             if qpu_shape[1] != 4:
                 raise ValueError('Method is suitable for Zephyr[m,t=4] only')
-            vec_to_lin = dnx.zephyr_coordinates(qpu_shape[0], qpu_shape[1]).zephyr_to_linear
+            vec_to_lin = dnx.zephyr_coordinates(*qpu_shape).zephyr_to_linear
             L = 4 * qpu_shape[0]
             dimensions = (L, L)
             to_chain = _squarenextneighbor_node_to_zephyr_chain

--- a/tests/test_decomposers.py
+++ b/tests/test_decomposers.py
@@ -699,7 +699,7 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
   
     def test_all_embedding_shapes(self):
         """Check embeddings match anticipated optimal dimensions for Chimera,
-        and Pegasus processors with Cubic and Native embeddings.
+        Pegasus and Zephyr processors with Cubic, Kings and Native embeddings.
         Uses a default processor scale of 4, with either 0 or 15
         edge defects.
         """
@@ -707,6 +707,7 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
         # tuple length, chain length, number of embeddings
         shape_dicts = {('zephyr', 'zephyr'): {'tl': 5, 'cl': 1, 'ne': 2}, # Implement later
                        ('zephyr', 'kings'): {'tl': 2, 'cl': 2, 'ne': 2},
+                       ('zephyr', 'cubic'): {'tl': 3, 'cl': 2, 'ne': 3},
                        ('pegasus', 'pegasus'): {'tl': 5, 'cl': 1, 'ne': 2},
                        ('pegasus', 'cubic'): {'tl': 3, 'cl': 2, 'ne': 3},
                        ('pegasus', 'kings'): {'tl': 2, 'cl': 2, 'ne': 2},
@@ -719,8 +720,9 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
             elif qpu_top == 'pegasus':
                 lattice_types = ['cubic', 'kings', qpu_top, None]
             elif qpu_top == 'zephyr':
-                lattice_types = ['kings']
-            
+                lattice_types = ['cubic', 'kings']
+            else:
+                raise ValueError('Uknown qpu topology')
             #Native by default:
             shape_dicts[(qpu_top, None)] = shape_dicts[(qpu_top, qpu_top)] 
             qpu_sampler = MockDWaveSampler(topology_type=qpu_top)
@@ -793,13 +795,15 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
                 lattice_types = ['cubic', qpu_top]
             elif qpu_top == 'zephyr':
                 qpu_shape = [qpu_scale, 4]
-                lattice_types = ['kings']
+                lattice_types = ['cubic', 'kings']
 
             for lattice_type in lattice_types:
                 # proposed_source: a defect free-lattice at sampler
                 # scale (hence inclusive of all keys).
                 if lattice_type == 'cubic':
-                    if qpu_top == 'pegasus':
+                    if qpu_top == 'zephyr':
+                        cubic_dims = (max(qpu_scale-1,1), max(qpu_scale-1,1), 16)
+                    elif qpu_top == 'pegasus':
                         cubic_dims = (qpu_scale-1, qpu_scale-1, 12)
                     else:
                         cubic_dims = (qpu_scale//2, qpu_scale//2, 8)
@@ -860,9 +864,9 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
                               'kings': (2,2)  # single cell
         }
         for qpu_top in ['pegasus', 'chimera', 'zephyr']:
-            lattice_types = []
+            lattice_types = ['cubic']
             if qpu_top != 'zephyr':
-                lattice_types += [qpu_top, 'cubic']
+                lattice_types += [qpu_top]
             if qpu_top != 'chimera':
                 lattice_types.append('kings')
 

--- a/tests/test_decomposers.py
+++ b/tests/test_decomposers.py
@@ -722,7 +722,7 @@ class TestMakeOriginEmbeddings(unittest.TestCase):
             elif qpu_top == 'zephyr':
                 lattice_types = ['cubic', 'kings']
             else:
-                raise ValueError('Uknown qpu topology')
+                raise ValueError('Unknown qpu topology')
             #Native by default:
             shape_dicts[(qpu_top, None)] = shape_dicts[(qpu_top, qpu_top)] 
             qpu_sampler = MockDWaveSampler(topology_type=qpu_top)


### PR DESCRIPTION
Creates chain length two embeddings on a target zephyr graph, permissive of node defects, with optional permissiveness of edge defects. Matches the template for other make_origin_embedding routines. 