### PR TITLE
Fix slow tests by upgrading `MockDWaveSampler`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,8 @@ minorminer==0.2.10; python_version<"3.12"
 minorminer==0.2.13; python_version~="3.12.0"
 minorminer==0.2.16; python_version~="3.13.0"
 
-# >=1.15.1 required as older versions are too restricitve on dwave-preprocessing
-dwave-system==1.15.1; python_version<"3.11"
+# >=1.16.0 required as MockDWaveSampler is prohibitively slow in older versions
+dwave-system==1.16.0; python_version<"3.11"
 dwave-system==1.18.0; python_version~="3.11.0"
 # >=1.23.0 required as older versions restrict networkx so it conflicts with dwave-samplers
 dwave-system==1.23.0; python_version>="3.12"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(package_info_path, encoding='utf-8') as f:
 # Package requirements, minimal pinning
 install_requires = ['numpy>=1.19.1', 'networkx', 'click>5', 'plucky>=0.4.3',
                     'dimod>=0.12.2,<0.13', 'dwave-preprocessing>=0.5.4',
-                    'minorminer>=0.1.7', 'dwave-networkx>=0.8.8', 'dwave-system>=1.15.1',
+                    'minorminer>=0.1.7', 'dwave-networkx>=0.8.8', 'dwave-system>=1.16.0',
                     'dwave-cloud-client>=0.10.6',   # avoid pydantic 2.0 backward compat break
                     'dwave-samplers>=1.0.0',    # combines neal, greedy, tabu and orang
                     ]


### PR DESCRIPTION
In older versions of dwave-system/`MockDWaveSampler`, `ExactSolver` is used without a cutoff on problem size, which makes some tests here (`LatticeLNLS`) too slow.