### PR TITLE
Release 0.6.15

### DIFF
--- a/hybrid/package_info.py
+++ b/hybrid/package_info.py
@@ -20,7 +20,7 @@ __all__ = [
 
 __package_name__ = 'dwave-hybrid'
 __title__ = 'D-Wave Hybrid'
-__version__ = '0.6.14'
+__version__ = '0.6.15'
 __author__ = 'D-Wave Systems Inc.'
 __author_email__ = 'radomir@dwavesys.com'
 __description__ = 'Hybrid Asynchronous Decomposition Solver Framework'


### PR DESCRIPTION
### New Features

- Add Python 3.14 support. See [\#308](https://github.com/dwavesystems/dwave-hybrid/pull/308).

- Add `origin_embeddings` as argument for LNLS reference example. See [\#309](https://github.com/dwavesystems/dwave-hybrid/pull/309).

### Bug Fixes

- Fix `exclude_dims` incorrect enumeration. See [\#309](https://github.com/dwavesystems/dwave-hybrid/pull/309).

### Upgrade Notes

- Drop support for Python 3.9. See [\#308](https://github.com/dwavesystems/dwave-hybrid/pull/308).