### PR TITLE
Release 0.6.16

### DIFF
--- a/hybrid/package_info.py
+++ b/hybrid/package_info.py
@@ -20,7 +20,7 @@ __all__ = [
 
 __package_name__ = 'dwave-hybrid'
 __title__ = 'D-Wave Hybrid'
-__version__ = '0.6.15'
+__version__ = '0.6.16'
 __author__ = 'D-Wave Systems Inc.'
 __author_email__ = 'radomir@dwavesys.com'
 __description__ = 'Hybrid Asynchronous Decomposition Solver Framework'


### PR DESCRIPTION
### Upgrade Notes

- Drop NumPy 1.x support.

### Bug Fixes

- Use `dwave-graphs` instead of the deprecated `dwave-networkx`. See [\#312](https://github.com/dwavesystems/dwave-hybrid/pull/312).
